### PR TITLE
Apply ownership in unpacked entries

### DIFF
--- a/cmd/oci-create-runtime-bundle/main.go
+++ b/cmd/oci-create-runtime-bundle/main.go
@@ -36,12 +36,13 @@ var bundleTypes = []string{
 }
 
 type bundleCmd struct {
-	stdout  *log.Logger
-	stderr  *log.Logger
-	typ     string // the type to bundle, can be empty string
-	ref     string
-	root    string
-	version bool
+	stdout    *log.Logger
+	stderr    *log.Logger
+	typ       string // the type to bundle, can be empty string
+	ref       string
+	root      string
+	sameOwner bool
+	version   bool
 }
 
 func main() {
@@ -87,10 +88,17 @@ func newBundleCmd(stdout, stderr *log.Logger) *cobra.Command {
 It is strongly recommended to keep the default value.`,
 	)
 
+	isUserRoot := os.Getuid() == 0
+	cmd.Flags().BoolVar(
+		&v.sameOwner, "same-owner", isUserRoot,
+		`Preserve the owner and group of the layer entries when unpacking the image (default for superuser, but not for ordinary users).`,
+	)
+
 	cmd.Flags().BoolVar(
 		&v.version, "version", false,
 		`Print version information and exit`,
 	)
+
 	return cmd
 }
 
@@ -124,7 +132,7 @@ func (v *bundleCmd) Run(cmd *cobra.Command, args []string) {
 	}
 
 	unpacker := &image.Unpacker{
-		PreserveOwnership: false,
+		PreserveOwnership: v.sameOwner,
 	}
 
 	var err error

--- a/cmd/oci-create-runtime-bundle/main.go
+++ b/cmd/oci-create-runtime-bundle/main.go
@@ -123,13 +123,17 @@ func (v *bundleCmd) Run(cmd *cobra.Command, args []string) {
 		v.typ = typ
 	}
 
+	unpacker := &image.Unpacker{
+		PreserveOwnership: false,
+	}
+
 	var err error
 	switch v.typ {
 	case image.TypeImageLayout:
-		err = image.CreateRuntimeBundleLayout(args[0], args[1], v.ref, v.root)
+		err = image.CreateRuntimeBundleLayout(unpacker, args[0], args[1], v.ref, v.root)
 
 	case image.TypeImage:
-		err = image.CreateRuntimeBundle(args[0], args[1], v.ref, v.root)
+		err = image.CreateRuntimeBundle(unpacker, args[0], args[1], v.ref, v.root)
 	}
 
 	if err != nil {

--- a/cmd/oci-create-runtime-bundle/oci-create-runtime-bundle.1.md
+++ b/cmd/oci-create-runtime-bundle/oci-create-runtime-bundle.1.md
@@ -23,6 +23,9 @@ runtime-spec-compatible `dest/config.json`.
 **--rootfs**
   A directory representing the root filesystem of the container in the OCI runtime bundle. It is strongly recommended to keep the default value. (default "rootfs")
 
+**--same-owner**
+  Preserve the owner and group of the layer entries when unpacking the image (default for superuser, but not for ordinary users).
+
 **--type**
   Type of the file to unpack. If unset, oci-create-runtime-bundle will try to auto-detect the type. One of "imageLayout,image"
 

--- a/cmd/oci-unpack/main.go
+++ b/cmd/oci-unpack/main.go
@@ -110,13 +110,17 @@ func (v *unpackCmd) Run(cmd *cobra.Command, args []string) {
 		v.typ = typ
 	}
 
+	unpacker := &image.Unpacker{
+		PreserveOwnership: false,
+	}
+
 	var err error
 	switch v.typ {
 	case image.TypeImageLayout:
-		err = image.UnpackLayout(args[0], args[1], v.ref)
+		err = image.UnpackLayout(unpacker, args[0], args[1], v.ref)
 
 	case image.TypeImage:
-		err = image.Unpack(args[0], args[1], v.ref)
+		err = image.Unpack(unpacker, args[0], args[1], v.ref)
 	}
 
 	if err != nil {

--- a/cmd/oci-unpack/oci-unpack.1.md
+++ b/cmd/oci-unpack/oci-unpack.1.md
@@ -17,6 +17,9 @@ oci-unpack \- Unpack an image or image source layout
 **--ref**
   The ref pointing to the manifest to be unpacked. This must be present in the "refs" subdirectory of the image. (default "v1.0")
 
+**--same-owner**
+  Preserve the owner and group of the layer entries when unpacking the image (default for superuser, but not for ordinary users).
+
 **--type**
   Type of the file to unpack. If unset, oci-unpack will try to auto-detect the type. One of "imageLayout,image"
 

--- a/image/image.go
+++ b/image/image.go
@@ -97,24 +97,24 @@ func validate(w walker, refs []string, out *log.Logger) error {
 // UnpackLayout walks through the file tree given by src and, using the layers
 // specified in the manifest pointed to by the given ref, unpacks all layers in
 // the given destination directory or returns an error if the unpacking failed.
-func UnpackLayout(src, dest, ref string) error {
-	return unpack(&unpacker{}, newPathWalker(src), dest, ref)
+func UnpackLayout(u *Unpacker, src, dest, ref string) error {
+	return unpack(u, newPathWalker(src), dest, ref)
 }
 
 // Unpack walks through the given .tar file and, using the layers specified in
 // the manifest pointed to by the given ref, unpacks all layers in the given
 // destination directory or returns an error if the unpacking failed.
-func Unpack(tarFile, dest, ref string) error {
+func Unpack(u *Unpacker, tarFile, dest, ref string) error {
 	f, err := os.Open(tarFile)
 	if err != nil {
 		return errors.Wrap(err, "unable to open file")
 	}
 	defer f.Close()
 
-	return unpack(&unpacker{}, newTarWalker(tarFile, f), dest, ref)
+	return unpack(u, newTarWalker(tarFile, f), dest, ref)
 }
 
-func unpack(u *unpacker, w walker, dest, refName string) error {
+func unpack(u *Unpacker, w walker, dest, refName string) error {
 	ref, err := findDescriptor(w, refName)
 	if err != nil {
 		return err
@@ -139,24 +139,24 @@ func unpack(u *unpacker, w walker, dest, refName string) error {
 // CreateRuntimeBundleLayout walks through the file tree given by src and
 // creates an OCI runtime bundle in the given destination dest
 // or returns an error if the unpacking failed.
-func CreateRuntimeBundleLayout(src, dest, ref, root string) error {
-	return createRuntimeBundle(&unpacker{}, newPathWalker(src), dest, ref, root)
+func CreateRuntimeBundleLayout(u *Unpacker, src, dest, ref, root string) error {
+	return createRuntimeBundle(u, newPathWalker(src), dest, ref, root)
 }
 
 // CreateRuntimeBundle walks through the given .tar file and
 // creates an OCI runtime bundle in the given destination dest
 // or returns an error if the unpacking failed.
-func CreateRuntimeBundle(tarFile, dest, ref, root string) error {
+func CreateRuntimeBundle(u *Unpacker, tarFile, dest, ref, root string) error {
 	f, err := os.Open(tarFile)
 	if err != nil {
 		return errors.Wrap(err, "unable to open file")
 	}
 	defer f.Close()
 
-	return createRuntimeBundle(&unpacker{}, newTarWalker(tarFile, f), dest, ref, root)
+	return createRuntimeBundle(u, newTarWalker(tarFile, f), dest, ref, root)
 }
 
-func createRuntimeBundle(u *unpacker, w walker, dest, refName, rootfs string) error {
+func createRuntimeBundle(u *Unpacker, w walker, dest, refName, rootfs string) error {
 	ref, err := findDescriptor(w, refName)
 	if err != nil {
 		return err

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -15,17 +15,13 @@
 package image
 
 import (
-	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
-	"time"
 
 	"github.com/opencontainers/image-spec/schema"
 	"github.com/opencontainers/image-spec/specs-go/v1"
@@ -85,175 +81,5 @@ func (m *manifest) validate(w walker) error {
 		}
 	}
 
-	return nil
-}
-
-func (m *manifest) unpack(w walker, dest string) (retErr error) {
-	// error out if the dest directory is not empty
-	s, err := ioutil.ReadDir(dest)
-	if err != nil && !os.IsNotExist(err) {
-		return errors.Wrap(err, "unable to open file") // err contains dest
-	}
-	if len(s) > 0 {
-		return fmt.Errorf("%s is not empty", dest)
-	}
-	defer func() {
-		// if we encounter error during unpacking
-		// clean up the partially-unpacked destination
-		if retErr != nil {
-			if err := os.RemoveAll(dest); err != nil {
-				fmt.Printf("Error: failed to remove partially-unpacked destination %v", err)
-			}
-		}
-	}()
-	for _, d := range m.Layers {
-		if d.MediaType != string(schema.MediaTypeImageLayer) {
-			continue
-		}
-
-		switch err := w.walk(func(path string, info os.FileInfo, r io.Reader) error {
-			if info.IsDir() {
-				return nil
-			}
-
-			dd, err := filepath.Rel(filepath.Join("blobs", d.algo()), filepath.Clean(path))
-			if err != nil || d.hash() != dd {
-				return nil
-			}
-
-			if err := unpackLayer(dest, r); err != nil {
-				return errors.Wrap(err, "error extracting layer")
-			}
-
-			return errEOW
-		}); err {
-		case nil:
-			return fmt.Errorf("%s: layer not found", dest)
-		case errEOW:
-		default:
-			return err
-		}
-	}
-	return nil
-}
-
-func unpackLayer(dest string, r io.Reader) error {
-	entries := make(map[string]bool)
-	gz, err := gzip.NewReader(r)
-	if err != nil {
-		return errors.Wrap(err, "error creating gzip reader")
-	}
-	defer gz.Close()
-
-	var dirs []*tar.Header
-	tr := tar.NewReader(gz)
-
-loop:
-	for {
-		hdr, err := tr.Next()
-		switch err {
-		case io.EOF:
-			break loop
-		case nil:
-			// success, continue below
-		default:
-			return errors.Wrapf(err, "error advancing tar stream")
-		}
-
-		hdr.Name = filepath.Clean(hdr.Name)
-		if !strings.HasSuffix(hdr.Name, string(os.PathSeparator)) {
-			// Not the root directory, ensure that the parent directory exists
-			parent := filepath.Dir(hdr.Name)
-			parentPath := filepath.Join(dest, parent)
-			if _, err2 := os.Lstat(parentPath); err2 != nil && os.IsNotExist(err2) {
-				if err3 := os.MkdirAll(parentPath, 0755); err3 != nil {
-					return err3
-				}
-			}
-		}
-		path := filepath.Join(dest, hdr.Name)
-		if entries[path] {
-			return fmt.Errorf("duplicate entry for %s", path)
-		}
-		entries[path] = true
-		rel, err := filepath.Rel(dest, path)
-		if err != nil {
-			return err
-		}
-		info := hdr.FileInfo()
-		if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-			return fmt.Errorf("%q is outside of %q", hdr.Name, dest)
-		}
-
-		if strings.HasPrefix(info.Name(), ".wh.") {
-			path = strings.Replace(path, ".wh.", "", 1)
-
-			if err := os.RemoveAll(path); err != nil {
-				return errors.Wrap(err, "unable to delete whiteout path")
-			}
-
-			continue loop
-		}
-
-		switch hdr.Typeflag {
-		case tar.TypeDir:
-			if fi, err := os.Lstat(path); !(err == nil && fi.IsDir()) {
-				if err2 := os.MkdirAll(path, info.Mode()); err2 != nil {
-					return errors.Wrap(err2, "error creating directory")
-				}
-			}
-
-		case tar.TypeReg, tar.TypeRegA:
-			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, info.Mode())
-			if err != nil {
-				return errors.Wrap(err, "unable to open file")
-			}
-
-			if _, err := io.Copy(f, tr); err != nil {
-				f.Close()
-				return errors.Wrap(err, "unable to copy")
-			}
-			f.Close()
-
-		case tar.TypeLink:
-			target := filepath.Join(dest, hdr.Linkname)
-
-			if !strings.HasPrefix(target, dest) {
-				return fmt.Errorf("invalid hardlink %q -> %q", target, hdr.Linkname)
-			}
-
-			if err := os.Link(target, path); err != nil {
-				return err
-			}
-
-		case tar.TypeSymlink:
-			target := filepath.Join(filepath.Dir(path), hdr.Linkname)
-
-			if !strings.HasPrefix(target, dest) {
-				return fmt.Errorf("invalid symlink %q -> %q", path, hdr.Linkname)
-			}
-
-			if err := os.Symlink(hdr.Linkname, path); err != nil {
-				return err
-			}
-		case tar.TypeXGlobalHeader:
-			return nil
-		}
-		// Directory mtimes must be handled at the end to avoid further
-		// file creation in them to modify the directory mtime
-		if hdr.Typeflag == tar.TypeDir {
-			dirs = append(dirs, hdr)
-		}
-	}
-	for _, hdr := range dirs {
-		path := filepath.Join(dest, hdr.Name)
-
-		finfo := hdr.FileInfo()
-		// I believe the old version was using time.Now().UTC() to overcome an
-		// invalid error from chtimes.....but here we lose hdr.AccessTime like this...
-		if err := os.Chtimes(path, time.Now().UTC(), finfo.ModTime()); err != nil {
-			return errors.Wrap(err, "error changing time")
-		}
-	}
 	return nil
 }

--- a/image/unpacker.go
+++ b/image/unpacker.go
@@ -1,0 +1,206 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package image
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/opencontainers/image-spec/schema"
+	"github.com/pkg/errors"
+)
+
+// unpacker is a structure that encapsulates the image layout unpacking
+// functionality.
+type unpacker struct{}
+
+// unpack finds the blobs of the layers that are specified in the manifest and
+// unpacks them in the specified destination directory.
+func (u *unpacker) unpack(m *manifest, w walker, dest string) (retErr error) {
+	// error out if the dest directory is not empty
+	s, err := ioutil.ReadDir(dest)
+	if err != nil && !os.IsNotExist(err) {
+		return errors.Wrap(err, "unable to open file") // err contains dest
+	}
+	if len(s) > 0 {
+		return fmt.Errorf("%s is not empty", dest)
+	}
+	defer func() {
+		// if we encounter error during unpacking
+		// clean up the partially-unpacked destination
+		if retErr != nil {
+			if err := os.RemoveAll(dest); err != nil {
+				fmt.Printf("Error: failed to remove partially-unpacked destination %v", err)
+			}
+		}
+	}()
+	for _, d := range m.Layers {
+		if d.MediaType != string(schema.MediaTypeImageLayer) {
+			continue
+		}
+
+		switch err := w.walk(func(path string, info os.FileInfo, r io.Reader) error {
+			if info.IsDir() {
+				return nil
+			}
+
+			dd, err := filepath.Rel(filepath.Join("blobs", d.algo()), filepath.Clean(path))
+			if err != nil || d.hash() != dd {
+				return nil
+			}
+
+			if err := unpackLayer(dest, r); err != nil {
+				return errors.Wrap(err, "error extracting layer")
+			}
+
+			return errEOW
+		}); err {
+		case nil:
+			return fmt.Errorf("%s: layer not found", dest)
+		case errEOW:
+		default:
+			return err
+		}
+	}
+	return nil
+}
+
+func unpackLayer(dest string, r io.Reader) error {
+	entries := make(map[string]bool)
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return errors.Wrap(err, "error creating gzip reader")
+	}
+	defer gz.Close()
+
+	var dirs []*tar.Header
+	tr := tar.NewReader(gz)
+
+loop:
+	for {
+		hdr, err := tr.Next()
+		switch err {
+		case io.EOF:
+			break loop
+		case nil:
+			// success, continue below
+		default:
+			return errors.Wrapf(err, "error advancing tar stream")
+		}
+
+		hdr.Name = filepath.Clean(hdr.Name)
+		if !strings.HasSuffix(hdr.Name, string(os.PathSeparator)) {
+			// Not the root directory, ensure that the parent directory exists
+			parent := filepath.Dir(hdr.Name)
+			parentPath := filepath.Join(dest, parent)
+			if _, err2 := os.Lstat(parentPath); err2 != nil && os.IsNotExist(err2) {
+				if err3 := os.MkdirAll(parentPath, 0755); err3 != nil {
+					return err3
+				}
+			}
+		}
+		path := filepath.Join(dest, hdr.Name)
+		if entries[path] {
+			return fmt.Errorf("duplicate entry for %s", path)
+		}
+		entries[path] = true
+		rel, err := filepath.Rel(dest, path)
+		if err != nil {
+			return err
+		}
+		info := hdr.FileInfo()
+		if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return fmt.Errorf("%q is outside of %q", hdr.Name, dest)
+		}
+
+		if strings.HasPrefix(info.Name(), ".wh.") {
+			path = strings.Replace(path, ".wh.", "", 1)
+
+			if err := os.RemoveAll(path); err != nil {
+				return errors.Wrap(err, "unable to delete whiteout path")
+			}
+
+			continue loop
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if fi, err := os.Lstat(path); !(err == nil && fi.IsDir()) {
+				if err2 := os.MkdirAll(path, info.Mode()); err2 != nil {
+					return errors.Wrap(err2, "error creating directory")
+				}
+			}
+
+		case tar.TypeReg, tar.TypeRegA:
+			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, info.Mode())
+			if err != nil {
+				return errors.Wrap(err, "unable to open file")
+			}
+
+			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				return errors.Wrap(err, "unable to copy")
+			}
+			f.Close()
+
+		case tar.TypeLink:
+			target := filepath.Join(dest, hdr.Linkname)
+
+			if !strings.HasPrefix(target, dest) {
+				return fmt.Errorf("invalid hardlink %q -> %q", target, hdr.Linkname)
+			}
+
+			if err := os.Link(target, path); err != nil {
+				return err
+			}
+
+		case tar.TypeSymlink:
+			target := filepath.Join(filepath.Dir(path), hdr.Linkname)
+
+			if !strings.HasPrefix(target, dest) {
+				return fmt.Errorf("invalid symlink %q -> %q", path, hdr.Linkname)
+			}
+
+			if err := os.Symlink(hdr.Linkname, path); err != nil {
+				return err
+			}
+		case tar.TypeXGlobalHeader:
+			return nil
+		}
+		// Directory mtimes must be handled at the end to avoid further
+		// file creation in them to modify the directory mtime
+		if hdr.Typeflag == tar.TypeDir {
+			dirs = append(dirs, hdr)
+		}
+	}
+	for _, hdr := range dirs {
+		path := filepath.Join(dest, hdr.Name)
+
+		finfo := hdr.FileInfo()
+		// I believe the old version was using time.Now().UTC() to overcome an
+		// invalid error from chtimes.....but here we lose hdr.AccessTime like this...
+		if err := os.Chtimes(path, time.Now().UTC(), finfo.ModTime()); err != nil {
+			return errors.Wrap(err, "error changing time")
+		}
+	}
+	return nil
+}

--- a/image/unpacker_test.go
+++ b/image/unpacker_test.go
@@ -106,13 +106,14 @@ func TestUnpackLayer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testManifest := manifest{
+	testManifest := &manifest{
 		Layers: []descriptor{descriptor{
 			MediaType: "application/vnd.oci.image.layer.tar+gzip",
 			Digest:    fmt.Sprintf("sha256:%s", fmt.Sprintf("%x", h.Sum(nil))),
 		}},
 	}
-	err = testManifest.unpack(newPathWalker(tmp1), filepath.Join(tmp1, "rootfs"))
+	u := &unpacker{}
+	err = u.unpack(testManifest, newPathWalker(tmp1), filepath.Join(tmp1, "rootfs"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,13 +168,14 @@ func TestUnpackLayerRemovePartialyUnpackedFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testManifest := manifest{
+	testManifest := &manifest{
 		Layers: []descriptor{descriptor{
 			MediaType: "application/vnd.oci.image.layer.tar+gzip",
 			Digest:    fmt.Sprintf("sha256:%s", fmt.Sprintf("%x", h.Sum(nil))),
 		}},
 	}
-	err = testManifest.unpack(newPathWalker(tmp1), filepath.Join(tmp1, "rootfs"))
+	u := &unpacker{}
+	err = u.unpack(testManifest, newPathWalker(tmp1), filepath.Join(tmp1, "rootfs"))
 	if err != nil && !strings.Contains(err.Error(), "duplicate entry for") {
 		t.Fatal(err)
 	}

--- a/image/unpacker_test.go
+++ b/image/unpacker_test.go
@@ -60,7 +60,10 @@ func TestUnpackLayerDuplicateEntries(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmp2)
-	if err := unpackLayer(tmp2, r); err != nil && !strings.Contains(err.Error(), "duplicate entry for") {
+	u := &Unpacker{
+		PreserveOwnership: false,
+	}
+	if err := u.unpackLayer(tmp2, r); err != nil && !strings.Contains(err.Error(), "duplicate entry for") {
 		t.Fatalf("Expected to fail with duplicate entry, got %v", err)
 	}
 }
@@ -112,7 +115,9 @@ func TestUnpackLayer(t *testing.T) {
 			Digest:    fmt.Sprintf("sha256:%s", fmt.Sprintf("%x", h.Sum(nil))),
 		}},
 	}
-	u := &unpacker{}
+	u := &Unpacker{
+		PreserveOwnership: false,
+	}
 	err = u.unpack(testManifest, newPathWalker(tmp1), filepath.Join(tmp1, "rootfs"))
 	if err != nil {
 		t.Fatal(err)
@@ -174,7 +179,7 @@ func TestUnpackLayerRemovePartialyUnpackedFile(t *testing.T) {
 			Digest:    fmt.Sprintf("sha256:%s", fmt.Sprintf("%x", h.Sum(nil))),
 		}},
 	}
-	u := &unpacker{}
+	u := &Unpacker{}
 	err = u.unpack(testManifest, newPathWalker(tmp1), filepath.Join(tmp1, "rootfs"))
 	if err != nil && !strings.Contains(err.Error(), "duplicate entry for") {
 		t.Fatal(err)


### PR DESCRIPTION
This patch will apply the user/group, found in the tar entry, to the unpacked
files, directories, and symlinks. It will only do so if the user running the
`oci-unpack` tool is root.

To test the patch, I used latest Ubuntu from Dockerhub, converted to OCI
format with `skopeo`:

``` bash
skopeo copy docker://ubuntu oci://$PWD/ubuntu
```

With the current `oci-unpack`, all files and directories are owned by the user
that does the unpacking:

``` bash
root@vagrant:/tmp# ls -la ubuntu-unpacked-old/etc/shadow
-rw-r----- 1 root root 652 Sep 15 17:17 ubuntu-unpacked-old/etc/shadow
```

With the proposed patch, the correct ownership is applied:

``` bash
root@vagrant:/tmp# ls -la ubuntu-unpacked/etc/shadow
-rw-r----- 1 root shadow 652 Sep 15 17:14 ubuntu-unpacked/etc/shadow
```
