### PR TITLE
Add --version to cmd to show version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 GO15VENDOREXPERIMENT=1
 export GO15VENDOREXPERIMENT
 
+COMMIT=$(shell git rev-parse HEAD 2> /dev/null || true)
+
 EPOCH_TEST_COMMIT ?= v0.2.0
 
 default: help
@@ -19,9 +21,9 @@ check-license:
 	@./.tool/check-license
 
 tools:
-	go build ./cmd/oci-create-runtime-bundle
-	go build ./cmd/oci-unpack
-	go build ./cmd/oci-image-validate
+	go build -ldflags "-X main.gitCommit=${COMMIT}" ./cmd/oci-create-runtime-bundle
+	go build -ldflags "-X main.gitCommit=${COMMIT}" ./cmd/oci-unpack
+	go build -ldflags "-X main.gitCommit=${COMMIT}" ./cmd/oci-image-validate
 
 lint:
 	@echo "checking lint"

--- a/cmd/oci-create-runtime-bundle/main.go
+++ b/cmd/oci-create-runtime-bundle/main.go
@@ -20,9 +20,14 @@ import (
 	"os"
 	"strings"
 
+	specs "github.com/opencontainers/image-spec/specs-go"
 	"github.com/opencontainers/image-tools/image"
 	"github.com/spf13/cobra"
 )
+
+// gitCommit will be the hash that the binary was built from
+// and will be populated by the Makefile
+var gitCommit = ""
 
 // supported bundle types
 var bundleTypes = []string{
@@ -31,11 +36,12 @@ var bundleTypes = []string{
 }
 
 type bundleCmd struct {
-	stdout *log.Logger
-	stderr *log.Logger
-	typ    string // the type to bundle, can be empty string
-	ref    string
-	root   string
+	stdout  *log.Logger
+	stderr  *log.Logger
+	typ     string // the type to bundle, can be empty string
+	ref     string
+	root    string
+	version bool
 }
 
 func main() {
@@ -81,10 +87,20 @@ func newBundleCmd(stdout, stderr *log.Logger) *cobra.Command {
 It is strongly recommended to keep the default value.`,
 	)
 
+	cmd.Flags().BoolVar(
+		&v.version, "version", false,
+		`Print version information and exit`,
+	)
 	return cmd
 }
 
 func (v *bundleCmd) Run(cmd *cobra.Command, args []string) {
+	if v.version {
+		v.stdout.Printf("commit: %s", gitCommit)
+		v.stdout.Printf("spec: %s", specs.Version)
+		os.Exit(0)
+
+	}
 	if len(args) != 2 {
 		v.stderr.Print("both src and dest must be provided")
 		if err := cmd.Usage(); err != nil {

--- a/cmd/oci-unpack/main.go
+++ b/cmd/oci-unpack/main.go
@@ -20,9 +20,14 @@ import (
 	"os"
 	"strings"
 
+	specs "github.com/opencontainers/image-spec/specs-go"
 	"github.com/opencontainers/image-tools/image"
 	"github.com/spf13/cobra"
 )
+
+// gitCommit will be the hash that the binary was built from
+// and will be populated by the Makefile
+var gitCommit = ""
 
 // supported unpack types
 var unpackTypes = []string{
@@ -31,10 +36,11 @@ var unpackTypes = []string{
 }
 
 type unpackCmd struct {
-	stdout *log.Logger
-	stderr *log.Logger
-	typ    string // the type to unpack, can be empty string
-	ref    string
+	stdout  *log.Logger
+	stderr  *log.Logger
+	typ     string // the type to unpack, can be empty string
+	ref     string
+	version bool
 }
 
 func main() {
@@ -73,11 +79,20 @@ func newUnpackCmd(stdout, stderr *log.Logger) *cobra.Command {
 		&v.ref, "ref", "v1.0",
 		`The ref pointing to the manifest to be unpacked. This must be present in the "refs" subdirectory of the image.`,
 	)
-
+	cmd.Flags().BoolVar(
+		&v.version, "version", false,
+		`Print version information and exit`,
+	)
 	return cmd
 }
 
 func (v *unpackCmd) Run(cmd *cobra.Command, args []string) {
+	if v.version {
+		v.stdout.Printf("commit: %s", gitCommit)
+		v.stdout.Printf("spec: %s", specs.Version)
+		os.Exit(0)
+	}
+
 	if len(args) != 2 {
 		v.stderr.Print("both src and dest must be provided")
 		if err := cmd.Usage(); err != nil {


### PR DESCRIPTION
Signed-off-by: Lei Jitang <leijitang@huawei.com>
Users should have a way to know the spec version and code commit of
the image-tool
````
[lei@fedora image-tools]$ ./oci-create-runtime-bundle --version
commit: 721ba581955c2b8ce1184d7492ed5e3f5ba3e1d4
spec: 0.3.0-dev
[lei@fedora image-tools]$ ./oci-image-validate --version
commit: 721ba581955c2b8ce1184d7492ed5e3f5ba3e1d4
spec: 0.3.0-dev
[lei@fedora image-tools]$ ./oci-unpack --version
commit: 721ba581955c2b8ce1184d7492ed5e3f5ba3e1d4
spec: 0.3.0-dev
````