### PR TITLE
validate media type of manifest and its descendants 

### DIFF
--- a/cmd/oci-image-validate/main.go
+++ b/cmd/oci-image-validate/main.go
@@ -149,7 +149,7 @@ func (v *validateCmd) validatePath(name string) error {
 
 	switch typ {
 	case image.TypeManifest:
-		return schema.MediaTypeManifest.Validate(f)
+		return image.ValidateManifestMediaType(f)
 	case image.TypeManifestList:
 		return schema.MediaTypeManifestList.Validate(f)
 	case image.TypeConfig:


### PR DESCRIPTION
migrate from opencontainers/image-spec/pull/273

cc @wking @runcom @stevvooe 

Signed-off-by: xiekeyang xiekeyang@huawei.com
