### PR TITLE
reduplicated condition

### DIFF
--- a/image/walker.go
+++ b/image/walker.go
@@ -74,12 +74,6 @@ loop:
 	return nil
 }
 
-type eofReader struct{}
-
-func (eofReader) Read(_ []byte) (int, error) {
-	return 0, io.EOF
-}
-
 type pathWalker struct {
 	root string
 }
@@ -101,10 +95,6 @@ func (w *pathWalker) walk(f walkFunc) error {
 		rel, err := filepath.Rel(w.root, path)
 		if err != nil {
 			return errors.Wrap(err, "error walking path") // err from filepath.Walk includes path name
-		}
-
-		if info.IsDir() { // behave like a tar reader for directories
-			return f(rel, info, eofReader{})
 		}
 
 		file, err := os.Open(path)


### PR DESCRIPTION
I read all `walkFunc` in `(*pathWalker).walk(f walkFunc)`, which are all deal with directory FileInfo condition. Here seems to be a reduplicated block.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>