### PR TITLE
Display correct runtime-spec version

### DIFF
--- a/image/config.go
+++ b/image/config.go
@@ -70,7 +70,7 @@ func (c *config) runtimeSpec(rootfs string) (*specs.Spec, error) {
 	}
 
 	var s specs.Spec
-	s.Version = "0.5.0"
+	s.Version = specs.Version
 	// we should at least apply the default spec, otherwise this is totally useless
 	s.Process.Terminal = true
 	s.Root.Path = rootfs


### PR DESCRIPTION
Instead of using a constant as the runtime-spec
version, user `Version` in the package.

Signed-off-by: Lei Jitang <leijitang@huawei.com>