### PR TITLE
Makefile: Add a pattern rule for oci-* commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ export GO15VENDOREXPERIMENT
 COMMIT=$(shell git rev-parse HEAD 2> /dev/null || true)
 
 EPOCH_TEST_COMMIT ?= v0.2.0
+TOOLS := \
+	oci-create-runtime-bundle \
+	oci-image-validate \
+	oci-unpack
 
 default: help
 
@@ -20,10 +24,10 @@ check-license:
 	@echo "checking license headers"
 	@./.tool/check-license
 
-tools:
-	go build -ldflags "-X main.gitCommit=${COMMIT}" ./cmd/oci-create-runtime-bundle
-	go build -ldflags "-X main.gitCommit=${COMMIT}" ./cmd/oci-unpack
-	go build -ldflags "-X main.gitCommit=${COMMIT}" ./cmd/oci-image-validate
+tools: $(TOOLS)
+
+oci-%: cmd/oci-%/main.go
+	go build -ldflags "-X main.gitCommit=${COMMIT}" ./cmd/$@
 
 lint:
 	@echo "checking lint"
@@ -69,10 +73,7 @@ install.tools: .install.gitvalidation .install.glide .install.glide-vc .install.
 	gometalinter --install --update
 
 clean:
-	rm -rf *~ $(OUTPUT_DIRNAME)
-	rm -f oci-create-runtime-bundle
-	rm -f oci-unpack
-	rm -f oci-image-validate
+	rm -rf *~ $(OUTPUT_DIRNAME) $(TOOLS)
 
 .PHONY: \
 	tools \

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ check-license:
 
 tools: $(TOOLS)
 
-oci-%: cmd/oci-%/main.go
+$(TOOLS): oci-%:
 	go build -ldflags "-X main.gitCommit=${COMMIT}" ./cmd/$@
 
 lint:
@@ -77,6 +77,7 @@ clean:
 
 .PHONY: \
 	tools \
+	$(TOOLS) \
 	check-license \
 	clean \
 	lint \


### PR DESCRIPTION
Make it easy to (re)build a single command without building all of them.  Using main.go as the only prerequisite cuts some corners, but prerequisites for this are hard ;).  With this commit, you can touch `main.go` to force a rebuild.  If that ends up being too awkward, we can make these `.PHONY` targets.

This is the current first commit in #5, to see if [nibbling away at that PR one commit at a time][1] makes review any easier.

[1]: https://github.com/opencontainers/image-tools/pull/5#issuecomment-248781012