### PR TITLE
descriptor validation

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -40,7 +40,7 @@ func Validate(tarFile string, refs []string, out *log.Logger) error {
 	}
 	defer f.Close()
 
-	return validate(newTarWalker(f), refs, out)
+	return validate(newTarWalker(tarFile, f), refs, out)
 }
 
 var validRefMediaTypes = []string{
@@ -111,7 +111,7 @@ func Unpack(tarFile, dest, ref string) error {
 	}
 	defer f.Close()
 
-	return unpack(newTarWalker(f), dest, ref)
+	return unpack(newTarWalker(tarFile, f), dest, ref)
 }
 
 func unpack(w walker, dest, refName string) error {
@@ -153,7 +153,7 @@ func CreateRuntimeBundle(tarFile, dest, ref, root string) error {
 	}
 	defer f.Close()
 
-	return createRuntimeBundle(newTarWalker(f), dest, ref, root)
+	return createRuntimeBundle(newTarWalker(tarFile, f), dest, ref, root)
 }
 
 func createRuntimeBundle(w walker, dest, refName, rootfs string) error {

--- a/image/reader.go
+++ b/image/reader.go
@@ -1,0 +1,84 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package image
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+type reader interface {
+	Get(desc descriptor) (io.ReadCloser, error)
+}
+
+type tarReader struct {
+	name string
+}
+
+func (r *tarReader) Get(desc descriptor) (io.ReadCloser, error) {
+	f, err := os.Open(r.name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	tr := tar.NewReader(f)
+loop:
+	for {
+		hdr, err := tr.Next()
+		switch err {
+		case io.EOF:
+			break loop
+		case nil:
+		// success, continue below
+		default:
+			return nil, err
+		}
+		if hdr.Name == filepath.Join("blobs", desc.algo(), desc.hash()) &&
+			!hdr.FileInfo().IsDir() {
+			buf, err := ioutil.ReadAll(tr)
+			if err != nil {
+				return nil, err
+			}
+			return ioutil.NopCloser(bytes.NewReader(buf)), nil
+		}
+	}
+
+	return nil, fmt.Errorf("object not found")
+}
+
+type layoutReader struct {
+	root string
+}
+
+func (r *layoutReader) Get(desc descriptor) (io.ReadCloser, error) {
+	name := filepath.Join(r.root, "blobs", desc.algo(), desc.hash())
+
+	info, err := os.Stat(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if info.IsDir() {
+		return nil, fmt.Errorf("object is dir")
+	}
+
+	return os.Open(name)
+}

--- a/image/walker.go
+++ b/image/walker.go
@@ -35,15 +35,17 @@ type walkFunc func(path string, _ os.FileInfo, _ io.Reader) error
 // calling walk for each file or directory in the tree.
 type walker interface {
 	walk(walkFunc) error
+	reader
 }
 
 type tarWalker struct {
 	r io.ReadSeeker
+	tarReader
 }
 
 // newTarWalker returns a Walker that walks through .tar files.
-func newTarWalker(r io.ReadSeeker) walker {
-	return &tarWalker{r}
+func newTarWalker(tarFile string, r io.ReadSeeker) walker {
+	return &tarWalker{r, tarReader{name: tarFile}}
 }
 
 func (w *tarWalker) walk(f walkFunc) error {
@@ -82,12 +84,13 @@ func (eofReader) Read(_ []byte) (int, error) {
 
 type pathWalker struct {
 	root string
+	layoutReader
 }
 
 // newPathWalker returns a Walker that walks through directories
 // starting at the given root path. It does not follow symlinks.
 func newPathWalker(root string) walker {
-	return &pathWalker{root}
+	return &pathWalker{root, layoutReader{root: root}}
 }
 
 func (w *pathWalker) walk(f walkFunc) error {


### PR DESCRIPTION
Function `(d *descriptor) validate()` is for descriptor variable, with which the exact cas file path is clear. So in this function, it is safely to open the target file, needn't to walk again.
Other walking mechanism is working properly, to need overall refactor, so I don't touch them hastily.

This PR refers to #5 , by @wking, on reading file part. I'm not very sure if this PR is valuable to be accepted individually. Otherwise we should close it and wait for #5 , or please @wking amend this PR with his singed-off?

As to me, I hope a cas reading/writing API can be used to code. 

Signed-off-by: xiekeyang <keyang.xie@gmail.com>

cc @wking @stevvooe 