### PR TITLE
Error out if rootfs type is not layers

### DIFF
--- a/image/config.go
+++ b/image/config.go
@@ -53,6 +53,10 @@ func findConfig(w walker, d *descriptor) (*config, error) {
 		if err := json.Unmarshal(buf, &c); err != nil {
 			return err
 		}
+		// check if the rootfs type is 'layers'
+		if c.RootFS.Type != "layers" {
+			return fmt.Errorf("'%s' is an unknown rootfs type, MUST be 'layers'", c.RootFS.Type)
+		}
 		return errEOW
 	}); err {
 	case nil:


### PR DESCRIPTION
The image spec requries that
````
MUST be set to layers. Implementations MUST generate an error if
they encounter a unknown value while verifying or unpacking an image.
```
The image-tool should act as the image spec says.

Signed-off-by: Lei Jiang <leijitang@huawei.com>