### PR TITLE
image/config: Replace `'%s'` with `%q`

### DIFF
--- a/image/config.go
+++ b/image/config.go
@@ -55,7 +55,7 @@ func findConfig(w walker, d *descriptor) (*config, error) {
 		}
 		// check if the rootfs type is 'layers'
 		if c.RootFS.Type != "layers" {
-			return fmt.Errorf("'%s' is an unknown rootfs type, MUST be 'layers'", c.RootFS.Type)
+			return fmt.Errorf("%q is an unknown rootfs type, MUST be 'layers'", c.RootFS.Type)
 		}
 		return errEOW
 	}); err {


### PR DESCRIPTION
As I [suggested earlier][1].  Fewer characters for us, and safer quoting for consumers.

[1]: https://github.com/opencontainers/image-tools/pull/32#discussion_r81357093