### PR TITLE
image/manifest: Recursively remove pre-existing entries when unpacking

### DIFF
--- a/image/manifest.go
+++ b/image/manifest.go
@@ -195,11 +195,27 @@ loop:
 			continue loop
 		}
 
+		if hdr.Typeflag != tar.TypeDir {
+			err = os.RemoveAll(path)
+			if err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		}
+
 		switch hdr.Typeflag {
 		case tar.TypeDir:
-			if fi, err := os.Lstat(path); !(err == nil && fi.IsDir()) {
-				if err2 := os.MkdirAll(path, info.Mode()); err2 != nil {
-					return errors.Wrap(err2, "error creating directory")
+			fi, err := os.Lstat(path)
+			if err != nil && !os.IsNotExist(err) {
+				return err
+			}
+			if os.IsNotExist(err) || !fi.IsDir() {
+				err = os.RemoveAll(path)
+				if err != nil && !os.IsNotExist(err) {
+					return err
+				}
+				err = os.MkdirAll(path, info.Mode())
+				if err != nil {
+					return err
 				}
 			}
 

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -160,101 +160,15 @@ loop:
 			return errors.Wrapf(err, "error advancing tar stream")
 		}
 
-		hdr.Name = filepath.Clean(hdr.Name)
-		if !strings.HasSuffix(hdr.Name, string(os.PathSeparator)) {
-			// Not the root directory, ensure that the parent directory exists
-			parent := filepath.Dir(hdr.Name)
-			parentPath := filepath.Join(dest, parent)
-			if _, err2 := os.Lstat(parentPath); err2 != nil && os.IsNotExist(err2) {
-				if err3 := os.MkdirAll(parentPath, 0755); err3 != nil {
-					return err3
-				}
-			}
-		}
-		path := filepath.Join(dest, hdr.Name)
-		if entries[path] {
-			return fmt.Errorf("duplicate entry for %s", path)
-		}
-		entries[path] = true
-		rel, err := filepath.Rel(dest, path)
+		var whiteout bool
+		whiteout, err = unpackLayerEntry(dest, hdr, tr, &entries)
 		if err != nil {
 			return err
 		}
-		info := hdr.FileInfo()
-		if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-			return fmt.Errorf("%q is outside of %q", hdr.Name, dest)
-		}
-
-		if strings.HasPrefix(info.Name(), ".wh.") {
-			path = strings.Replace(path, ".wh.", "", 1)
-
-			if err := os.RemoveAll(path); err != nil {
-				return errors.Wrap(err, "unable to delete whiteout path")
-			}
-
+		if whiteout {
 			continue loop
 		}
 
-		if hdr.Typeflag != tar.TypeDir {
-			err = os.RemoveAll(path)
-			if err != nil && !os.IsNotExist(err) {
-				return err
-			}
-		}
-
-		switch hdr.Typeflag {
-		case tar.TypeDir:
-			fi, err := os.Lstat(path)
-			if err != nil && !os.IsNotExist(err) {
-				return err
-			}
-			if os.IsNotExist(err) || !fi.IsDir() {
-				err = os.RemoveAll(path)
-				if err != nil && !os.IsNotExist(err) {
-					return err
-				}
-				err = os.MkdirAll(path, info.Mode())
-				if err != nil {
-					return err
-				}
-			}
-
-		case tar.TypeReg, tar.TypeRegA:
-			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, info.Mode())
-			if err != nil {
-				return errors.Wrap(err, "unable to open file")
-			}
-
-			if _, err := io.Copy(f, tr); err != nil {
-				f.Close()
-				return errors.Wrap(err, "unable to copy")
-			}
-			f.Close()
-
-		case tar.TypeLink:
-			target := filepath.Join(dest, hdr.Linkname)
-
-			if !strings.HasPrefix(target, dest) {
-				return fmt.Errorf("invalid hardlink %q -> %q", target, hdr.Linkname)
-			}
-
-			if err := os.Link(target, path); err != nil {
-				return err
-			}
-
-		case tar.TypeSymlink:
-			target := filepath.Join(filepath.Dir(path), hdr.Linkname)
-
-			if !strings.HasPrefix(target, dest) {
-				return fmt.Errorf("invalid symlink %q -> %q", path, hdr.Linkname)
-			}
-
-			if err := os.Symlink(hdr.Linkname, path); err != nil {
-				return err
-			}
-		case tar.TypeXGlobalHeader:
-			return nil
-		}
 		// Directory mtimes must be handled at the end to avoid further
 		// file creation in them to modify the directory mtime
 		if hdr.Typeflag == tar.TypeDir {
@@ -272,4 +186,105 @@ loop:
 		}
 	}
 	return nil
+}
+
+// unpackLayerEntry unpacks a single entry from a layer.
+func unpackLayerEntry(dest string, header *tar.Header, reader io.Reader, entries *map[string]bool) (whiteout bool, err error) {
+	header.Name = filepath.Clean(header.Name)
+	if !strings.HasSuffix(header.Name, string(os.PathSeparator)) {
+		// Not the root directory, ensure that the parent directory exists
+		parent := filepath.Dir(header.Name)
+		parentPath := filepath.Join(dest, parent)
+		if _, err2 := os.Lstat(parentPath); err2 != nil && os.IsNotExist(err2) {
+			if err3 := os.MkdirAll(parentPath, 0755); err3 != nil {
+				return false, err3
+			}
+		}
+	}
+	path := filepath.Join(dest, header.Name)
+	if (*entries)[path] {
+		return false, fmt.Errorf("duplicate entry for %s", path)
+	}
+	(*entries)[path] = true
+	rel, err := filepath.Rel(dest, path)
+	if err != nil {
+		return false, err
+	}
+	info := header.FileInfo()
+	if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return false, fmt.Errorf("%q is outside of %q", header.Name, dest)
+	}
+
+	if strings.HasPrefix(info.Name(), ".wh.") {
+		path = strings.Replace(path, ".wh.", "", 1)
+
+		if err = os.RemoveAll(path); err != nil {
+			return true, errors.Wrap(err, "unable to delete whiteout path")
+		}
+
+		return true, nil
+	}
+
+	if header.Typeflag != tar.TypeDir {
+		err = os.RemoveAll(path)
+		if err != nil && !os.IsNotExist(err) {
+			return false, err
+		}
+	}
+
+	switch header.Typeflag {
+	case tar.TypeDir:
+		fi, err := os.Lstat(path)
+		if err != nil && !os.IsNotExist(err) {
+			return false, err
+		}
+		if os.IsNotExist(err) || !fi.IsDir() {
+			err = os.RemoveAll(path)
+			if err != nil && !os.IsNotExist(err) {
+				return false, err
+			}
+			err = os.MkdirAll(path, info.Mode())
+			if err != nil {
+				return false, err
+			}
+		}
+
+	case tar.TypeReg, tar.TypeRegA:
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, info.Mode())
+		if err != nil {
+			return false, errors.Wrap(err, "unable to open file")
+		}
+
+		if _, err := io.Copy(f, reader); err != nil {
+			f.Close()
+			return false, errors.Wrap(err, "unable to copy")
+		}
+		f.Close()
+
+	case tar.TypeLink:
+		target := filepath.Join(dest, header.Linkname)
+
+		if !strings.HasPrefix(target, dest) {
+			return false, fmt.Errorf("invalid hardlink %q -> %q", target, header.Linkname)
+		}
+
+		if err := os.Link(target, path); err != nil {
+			return false, err
+		}
+
+	case tar.TypeSymlink:
+		target := filepath.Join(filepath.Dir(path), header.Linkname)
+
+		if !strings.HasPrefix(target, dest) {
+			return false, fmt.Errorf("invalid symlink %q -> %q", path, header.Linkname)
+		}
+
+		if err := os.Symlink(header.Linkname, path); err != nil {
+			return false, err
+		}
+	case tar.TypeXGlobalHeader:
+		return false, nil
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
Implementing the logic that is in-flight with opencontainers/image-spec#317, but [using recursive removal](https://github.com/opencontainers/image-spec/pull/317/files#r79214718).  GNU tar has a `--recursive-unlink` option that's not enabled by default, with the motivation being something like “[folks would be mad if we blew away a full tree and replaced it with a broken symlink](https://www.gnu.org/software/tar/manual/html_node/Dealing-with-Old-Files.html)”.  That makes sense for working filesystems, but we're building the rootfs from scratch here so losing information is not a concern.  This commit always uses recursive removal to get that old thing off the filesystem (whatever it takes ;).

The exception to the removal is if both the tar entry and existing path occupant are directories.  In this case we want to use GNU tar's default `--overwrite-dir` behavior, but `unpackLayer`'s metadata handling is currently very weak (the in-flight #3 strengthens it a bit) so I've left it at “don't delete the old directory”.

The reworked directory case also fixes a minor bug from 44210d05 (opencontainers/image-spec#177) where the:

```
if fi, err := os.Lstat(path); !(err == nil && fi.IsDir()) {
```

block would not error out if the `Lstat` failed for a reason besides the acceptable `IsNotExist`.  Instead, it would attempt to call `MkdirAll`, which would probably fail for the same reason that `Lstat` failed (ENOTDIR?).  But it's better to handle the `Lstat` errors directly.

Fixes #41.
