### PR TITLE
makefile: use full package name when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ export GO15VENDOREXPERIMENT
 COMMIT=$(shell git rev-parse HEAD 2> /dev/null || true)
 
 EPOCH_TEST_COMMIT ?= v0.2.0
+PACKAGE := github.com/opencontainers/image-tools
 TOOLS := \
 	oci-create-runtime-bundle \
 	oci-image-validate \
@@ -27,7 +28,7 @@ check-license:
 tools: $(TOOLS)
 
 $(TOOLS): oci-%:
-	go build -ldflags "-X main.gitCommit=${COMMIT}" ./cmd/$@
+	go build -ldflags "-X main.gitCommit=${COMMIT}" $(PACKAGE)/cmd/$@
 
 lint:
 	@echo "checking lint"


### PR DESCRIPTION
While ./cmd/... works in the canonical Go setup, I have a very
interesting Go setup involving symlinks within my GOPATH. It turns out
that Go doesn't like this very much and the only way to solve it is to
either stop using Go's inbuilt vendoring or build everything using the
full Go import.

The sort of errors you get are that the same type cannot be used in a
function call because the function signature was imported from a
different path.

Signed-off-by: Aleksa Sarai <asarai@suse.de>