### PR TITLE
Update dependencies to work with new layer media type

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,24 +1,24 @@
-hash: 14550151b754f92de80e864f26da93e8adfce71537c9cb7883b0bdd67e541453
-updated: 2016-09-15T10:25:30.038113538+02:00
+hash: 39d560704f0f624aca70d4f729b3cf4880898b8d8010bfd3d1e955c078a044cb
+updated: 2016-10-25T20:09:36.015161372Z
 imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/opencontainers/image-spec
-  version: 7e6e2f76d6a11cdcb3f3e334e3f12179a0f37dad
+  version: 7a6820ed62065744e9142ec93da4b37cc86fed5a
   subpackages:
   - schema
-  - specs-go/v1
   - specs-go
+  - specs-go/v1
 - name: github.com/opencontainers/runtime-spec
-  version: 06479209bdc0d4135911688c18157bd39bd99c22
+  version: 7dab1a245d3e13d0ad03b77409d0bf7e00a6ada4
   subpackages:
   - specs-go
 - name: github.com/pkg/errors
   version: 17b591df37844cde689f4d5813e5cea0927d8dd2
 - name: github.com/spf13/cobra
-  version: 9c28e4bbd74e5c3ed7aacbc552b2cab7cfdfe744
+  version: 856b96dcb49d6427babe192998a35190a12c2230
 - name: github.com/spf13/pflag
-  version: 7b17cc4658ef5ca157b986ea5c0b43af7938532b
+  version: 5ccb023bc27df288a957c5e994cd44fd19619465
 - name: github.com/xeipuuv/gojsonpointer
   version: e0fe6f68307607d540ed8eac07a342c33fa1b54a
 - name: github.com/xeipuuv/gojsonreference
@@ -26,7 +26,7 @@ imports:
 - name: github.com/xeipuuv/gojsonschema
   version: d5336c75940ef31c9ceeb0ae64cf92944bccb4ee
 - name: go4.org
-  version: e7a2449258501866491620d4f47472e6100ca551
+  version: 399a9d7bfe85437346a5ec4ef0450fc2f1084e61
   subpackages:
   - errorutil
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/opencontainers/image-tools
 import:
 - package: github.com/opencontainers/image-spec
-  version: 7e6e2f76d6a11cdcb3f3e334e3f12179a0f37dad
+  version: 7a6820ed62065744e9142ec93da4b37cc86fed5a
   subpackages:
   - schema
   - specs-go/v1

--- a/image/config.go
+++ b/image/config.go
@@ -116,6 +116,7 @@ func (c *config) runtimeSpec(rootfs string) (*specs.Spec, error) {
 	swap := uint64(c.Config.MemorySwap)
 	shares := uint64(c.Config.CPUShares)
 
+	s.Linux = new(specs.Linux)
 	s.Linux.Resources = &specs.Resources{
 		CPU: &specs.CPU{
 			Shares: &shares,

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -103,7 +103,7 @@ var (
     "layers": [
         {
             "digest": "<layer_digest>",
-            "mediaType": "application/vnd.oci.image.layer.tar+gzip",
+            "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
             "size": <layer_size>
         }
     ],

--- a/image/manifest_test.go
+++ b/image/manifest_test.go
@@ -108,7 +108,7 @@ func TestUnpackLayer(t *testing.T) {
 
 	testManifest := manifest{
 		Layers: []descriptor{descriptor{
-			MediaType: "application/vnd.oci.image.layer.tar+gzip",
+			MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
 			Digest:    fmt.Sprintf("sha256:%s", fmt.Sprintf("%x", h.Sum(nil))),
 		}},
 	}
@@ -169,7 +169,7 @@ func TestUnpackLayerRemovePartialyUnpackedFile(t *testing.T) {
 
 	testManifest := manifest{
 		Layers: []descriptor{descriptor{
-			MediaType: "application/vnd.oci.image.layer.tar+gzip",
+			MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
 			Digest:    fmt.Sprintf("sha256:%s", fmt.Sprintf("%x", h.Sum(nil))),
 		}},
 	}

--- a/vendor/github.com/opencontainers/image-spec/schema/fs.go
+++ b/vendor/github.com/opencontainers/image-spec/schema/fs.go
@@ -204,95 +204,96 @@ var _escData = map[string]*_escFile{
 
 	"/config-schema.json": {
 		local:   "config-schema.json",
-		size:    710,
-		modtime: 1466466955,
+		size:    774,
+		modtime: 1477035771,
 		compressed: `
-H4sIAAAJbogA/5SRPW7DMAyFd5/CcDLWUYdOWXuADj2BKlMxA1gUSGYICt+9+olbGygKdzGMx/e9J1Gf
-Tdt2A4hjjIoUunPbvUUIrxTUYgBu05/HS/sewaFHZ4vrKWNHcSNMNiOjajwbcxUKfVVPxBczsPXaP7+Y
-qh0qh8OCSGIotbmlTQpW3QYnewHjSn8l9R4hs/RxBadVi5wSWBEkTfJ1kuYYrMLwLaxQUcZQ44ruiSer
-eTIkpFecoCuzuVo6e9OR+I+orZvdiJoOd2PYy5DsdT52sXIfGXw5PHjp6/iUX+FgkoIB82vJssNNFhOp
-l/9nPbhN1oiixPffrmGZ7f1n3Wk307p0d+1S8eDmZvnOzdx8BQAA//964XeexgIAAA==
+H4sIAAAJbogA/5SRsW4DIQyG93sKRDL2QodOt+YBOnSsOlAwOUc6TI0zRFXevQJyTU6KquvCYP/f/2P7
+u1NKe8iOMQlS1IPSrwninqJYjMBqTzHgQb0lcBjQ2ap6Ktg2uxEmW5BRJA3GHDPFvlV3xAfj2Qbpn19M
+q20ah35G8mAMJYhuTssVa2qDkz2AcTW/kXJOUFj6PIKTVktMCVgQsh5UGUcp7RisgP8t3KFZGGOzq/VA
+PFkpHW8FesEJdO1dmkTbk4zEf1gt1exGFHByYljLUF6rvO7iTr1lCPXzEHLf2rtyhY3xEDBiuVaed7jw
+YiIJ+f9eV27hNWIW4vOjMSyzPd/WjQLTfejq2Dniyl26+a1/0AxfJ+R68vcHl7htejl9p9RHd+l+AgAA
+//9eW+CxBgMAAA==
 `,
 	},
 
 	"/content-descriptor.json": {
 		local:   "content-descriptor.json",
-		size:    616,
-		modtime: 1466180793,
+		size:    637,
+		modtime: 1476325139,
 		compressed: `
-H4sIAAAJbogA/4yRMVPDMAyF9/wKXdqR1gxMXWFngI1jcG0lVe9iG1kMhet/x4oTSGGgW/L8vvck+7MB
-aD1mx5SEYmh30D4mDPcxiKWADPqFQeBhMkWGp4SOOnJ2JG40Yp3dAQer+EEk7Yw55hg2Vd1G7o1n28nm
-9s5UbVU58jOSCxNLs5ub84hVt/Hf7ZWTU0Il4/6ITqqWuPAshLmc6GJFG9CTfa7mKv3dVw4Io09DIXag
-AmOHXKZBD4uOEV+XM+U8dnlDg+1xq8uuyj8F0tRsfnpH6lzhNtPHf5OoBSjA/iSYr5hmvgkqz9QjX/Z5
-6jHLsvGa4SeqJjVTWsv49k6M+mAvvy93ud5ldfl5bc7NVwAAAP//Zc2MR2gCAAA=
+H4sIAAAJbogA/5SRP0/DMBDF93yKk9uR1gwVQ1bYGWBDDKn93F6l2sY+hoL63dHFLaQwAFt0er/3J37v
+iIxHdYWzcIqmJ3OfEW9TlIEjCukXotDdSZQKPWQ4DuyGkbhSi3l1W+wHxbciubd2V1NctOsylY31ZQiy
+uF7Zdps1jv0Zqb21KSO6c3Idsaa2/jO9cXLIUDKtd3DSbrmkjCKManrSYURmD8/DYxO308+9sgWNOjWl
+FEgPBQEF0cHTJGPE5wVBOY9QF7wfNljq2JlH4MjqWu1X7kgdG2wqv/3WRCXEkdYHQf1nm9bDTotwlJvV
+ZQnPG1SZ1vjLohPVnLqTmyl4eeUCfcWn7398uvkyuiN67o7dRwAAAP//zGqYSn0CAAA=
 `,
 	},
 
 	"/defs-config.json": {
 		local:   "defs-config.json",
-		size:    2154,
-		modtime: 1466467007,
+		size:    2270,
+		modtime: 1476325139,
 		compressed: `
-H4sIAAAJbogA/+RVzY7TMBC+5ymswLGwF8SB6y5HVKQIOCBUucl4O0vsscYTIEL77jjZquSnCWlLT3uo
-mkz8/cyMPf6dKJUWEHJGL0gufafSOzDosHkLymsWzKtSsxJSaw/ulpxodMAqPhm8V5mHHA3musWvnggP
-DJGw0YjBvF1+eI8RqT00grR9gFxaaBv3TB6iLoTO6hj/FIB7kQ5HEEZ3nx4+Pa7+4j6AJa6HyJcMpkFG
-s+H1QyD34qbj+wadvH0zx5f91P7/cd76KttpHqR8EeX7X54CFB+J5VRWq33WFnT91Jrj/O7HVDc0s67T
-VfcTCtihjZn+RakJUeHaU0x7qE0O1k1OX3sCfblZizM2/2G1b3dgedaFq8qyz9Tl+XZ8q9ji2eb+mcrK
-jg/JwvzP3fXXzuoL8fcoe4fLx1vS/d9zpUwkJlwyYgs0ZoPFqMDXP9ilroEndZflv8Mg/Ul/cgFyBi0w
-OmADH70CGGKrpd1XEfpK0MLxgakr2dFZN9je1WY7usUWoclaGA/MJVCwXupN25sp+JaoBO0me5M0v8fk
-TwAAAP//dkZ6ZWoIAAA=
+H4sIAAAJbogA/+RVzY7TMBC+5ylGhmNhL4jDXrscUZEq4IBQ5SbjdpbYY8YTIEJ9d5Rs6eanDd1detpD
+VcX29zMznvHvDMAUmHKhqMTBXIO5QUeBmq8E0YpSXpVWQBkWEcOcg1oKKDDn4GgDy4g5Ocpti5/dER4Y
+zDU0GgAmb48fvgGM1hEbQV7fYq4ttF2PwhFFCVPnNID5mFB6Kx2OpEJhYw5bu9k97j16lnqIfCnoGmSB
+Lr2+TRxeXHV8X1HQt2+m+JY/bfx/nPNYLbdWBiE/ifLdr8gJiw8s+lBWb+OyTejirjTH+cOPU9WwIrY2
+s+4WKfqhjYn6AexOiKrUkSnoUJsDLpqYvvQE+nKTFids/sNq3+7A8qSLUJVln6nL8/X4VfHFs439E5eV
+HzfJmfE/9tZfOqrPLN8obG7o/PGWdf/3XEaY1aWnjNiCnFtRMUrw5Rt7f34q+p4shsqPKm5KW6Mkczzj
+2UDVCH6vSLDo8dznYOgu6zL+zfmWkvZflwcnPRe0iqOmnoresXir7V22iq+UPB4f0rbSLT/q1dy7Wq1H
+L+dZaPYex0P6HCj6qPWqreQp+Jq5RBtO9kPW/HbZnwAAAP//X8Yig94IAAA=
 `,
 	},
 
 	"/defs-image.json": {
 		local:   "defs-image.json",
-		size:    2528,
-		modtime: 1466438460,
+		size:    2550,
+		modtime: 1476325139,
 		compressed: `
-H4sIAAAJbogA/7RWy27bMBC8+ysIJUAOfqjXGkGAoEGBnlIgPTVQgY20kphKpLqkgzqB/r2k3k+nrt0b
-ueQOZ4Zjym8LxpwAlU8801wKZ8ucOwy54HamWAakub9LgJiW7D5D8UkKDVwgsS8pRMgeMvR5yH0o2lcl
-XgNg8OwRpphiwOHbPsOmZIo8sAfGWmdq67rSwPs1vNpIilzlx5iCy+1RbguxqgF0CegoTVxEbT0DrZEK
-OT8eYf3qLd3HD+uPZnS7/r5ZestLp9ialx1OwCNUukttYIqOkfm0z7SMCLKY+8ww83+qXcrKXiZDZjfJ
-p2f09YpxUUwrIuzqOgYV32yvY/wNgbEshaTqvLk6Xo/R4i23ZhTerj8Xk4GgFAQPDfhdJUPSCb6PsUaE
-S9ltnfDXjhPacx6rWi8Eq7ao+GtvXt1Fp5IloENJqVOVvNYXMuRNRFF15M2kbe5ai71WR32FhCGSsQQD
-NpBVQFyaddt70cl5J5vN1nyo8X0qdptNztNeo/pLOvUNcKExQpo+f5TveSXV1kmY5iIGQMflqUGZ1DGl
-cTJNxQqQH3NtGnaEvR6zJpXTKXg9xJngjDGHq/+s1j1AdfzL7y3nY2Hno2XATiSzeTEnlCk+H6kG9FRy
-IYJ1/LyWtaiz9IAI9uNlk4B0iss7woy0g0JfgDiI4S/8aL8OmfXfhI2gIAiKxwiSr92faQiJwsWcJ+24
-HuW9LyIIITX0/5UcHYEuSPMRkgLvw97TNPnKmkdWbZ6VFBdu78sB2UPhy8PAnY4vb1MPpdgliTMS7S3q
-Wb7IF38CAAD//wKthPngCQAA
+H4sIAAAJbogA/7RWTW/bMAy951cQaoEeEsc9DAMaFAWG9bJTB3SnBdnAynSszpY0SimWFv7vgx3Hn3GL
+rNnNosin96hn2i8TABGRk6ysV0aLBYhbipVWxcqBRfZKblJk8AbuLOnPRntUmhi+ZLgmuLckVawkluWz
+HV4NIBZQHAEgMooUfttaqkMAQkXFgYn31i3C0FjScg/v5obXoZMJZRiq4qiwgZjtAfwOUDjPSq+buEXv
+iUs5P5YYPK+m4fIyuMLg+VPwfT5dTc9FmZrvKkSk1uR8m1qvKT4hkLy13qwZbaIkyITkL7fJYFcLJoYi
+yTw8kvQzULpcVkTg4jpBl9wsrhP6gxFJlWFaVd5cHK/nMrj6OZ0Hq+liiUF8GVwNFGWoVUzO31Y6DL+j
+8UOsAeOd7ibO9HujmIpzllWs44JZE3TqubOuLqMVsSn62HAmqtCqaQwbS+wVuZa8EbuN3WuZW+jY3yFT
+TExaUgQ9WSXEOVNc1J61jN4yZ52a9zW+TaVIK6zzsPXkjqQTUezmj87os7BNTGn/8cNhUgPXj8urUg/C
+1LfTAzrOZDVKR9yIvcYtVu4gy0R5kn7D1KkBEMaJVmDVQRxx0xCzv/vPasNXqA7nQWc7Hwo7HS3j3ktm
+/kTsdtY+Haka9L3kYsKi46dtWYM6Sg+ZcTvcVp6yQ1zeEAaQvyr0CVmh7r/hR/frtWb9N2EDKIyichhh
++rX9msaYOpqM9aR53j/lnc8kam08dv9VjrZAG6T+MhlNd3FnNB2csiNTO0N7X/blvtedVl9eDg1KvUlT
+MRC9muxX+SSf/A0AAP//XF/NGfYJAAA=
 `,
 	},
 
 	"/defs.json": {
 		local:   "defs.json",
 		size:    3193,
-		modtime: 1466180793,
+		modtime: 1476325139,
 		compressed: `
-H4sIAAAJbogA/7RWTXPaMBC98ys8tEfa2PIX9NYp/cghAzOZnjo9uGYBtSCpstxpmuG/VzLGWPZiMKWH
-JPau9r23T6tYzwPHGS4gSyUVinI2fOMMp7CkjJq3zMkzWDhqLXm+WvNc6UdwZgLYO85UQhlI51FASpc0
-TYry0R6vAtB4hkIHKVPj6k2/qycBhk3HYQWyqCwSW127zbc698oj42M4+V2GPRIXwd2oQvaivtA+iSMM
-3MRb8D7pC0+8IA7GfhRgHFWyRRQFfYkmhPh+TFw/GodBHEeu6yKMyCqLOr9idzAeEoYt3N57gwFHYei3
-oXvvCwYdkEkwiWIyaeP33g4M3xsHQRQHgRv7sTsJQ4KZ70VzbnBlnZAzmC114EsZcKpUkX4pwWSHL+5q
-B+6utLxauBvh1YduWL7Z1FaXT18RL26pUDt7U4WZkpSt+is8cOzrb6tpm4jHAnb/Gxsl/u07pOo4SSJR
-Wj+bSy5AKgpZrUinXz97o50V6mphUP/bEjXbU/9nUSXWGVGf76d1IafHRh94q/DjtYVvpUyeZktdn2EW
-JCZ9dIAq2Da6xqmMHrTDkm9v/ZWU+EbbPB/oBuaJWmMM9brD+vfs13kDG+ItgE+c/6gjiBNTImxRHWxV
-C9hh1DatsstwMNVNNLDa7wAzPp0Z4pLPGHLTmSocRhnvpw+JEI1/Lac2YM0zZZ2WDsr6iWlalh5ufrcA
-y+gfuBIFdeSB50xd4kbGc5leSN09kPryrChLysvzP8NxYd+bO6EuGfFy/Pp9MqoplfAzpxIW1hfU6nnU
-MrVJbn8cB+ZnN/gbAAD//0JyEpx5DAAA
+H4sIAAAJbogA/7SWQZPSMBTH73yKTPSIbpumLXBzRNc97MDMjifHQy0PiEIS09Rx3eG7OymlNG0oFPGw
+C03yfv/3/nmheRkghBeQpYpJzQTHE4SnsGScmacM5RkskF4rka/WItdIrwHNJPD3guuEcVDoSULKlixN
+ivDhnlcB8AQZCYQw43pUPSGE9bMEo8a4hhWoIrKY2DLOtvkWT9Abn4yOw8nvctgncTG4G1ZkP+qLDkgc
+ueBmvIUPSF888WlMR0FEXRrVZEsoon2FxoQEQUy8IBqFNI4jz/Mcio5VlnR+xe64dEgYtri998YFjsIw
+aKN774sLTcmYjqOYjNv83tvh4vsjSqOYUi8OYm8chsRlvh/NheGquqDgMFviCfpSDqBqqph+rcDM4ld3
+tQN3V1peLdwN3dGHani+2dRWl9++Ory4ZYYRvW2GmVaMr/pneNDYx982p20inwrs/r+rlcS375DqYyfJ
+RGtQfK6EBKUZZLUghPDbF3+4s4a6ShjUP1tJzfbS/zmpknUmqc8P03oip9smINgKvL828J1SyfNsef8w
+zVwWJGb66ADTsG1U7ZYy+TgrLPX21l8p6d5oW+cj28A80WuXQj3usP4D/3XewEbyFuCTED/qBHmiS6Sd
+VIdaVYLrMOJErbLLOK6smzSwyu+AGZ/ONHGpZwy5aU8VDjsVH6aPiZSNn5ZTG7AWmbZOS4dk/cQ0LUsP
+N79bwDL2B66kOB15FDnXl7iRiVylF0p3N+QCMs14Ul6e/xknpH1v7kRd0uJl+/V7ZVRdquBnzhQsrDeo
+VfOwZWpT3H45DszfbvA3AAD//0JyEpx5DAAA
 `,
 	},
 
 	"/image-manifest-schema.json": {
 		local:   "image-manifest-schema.json",
 		size:    1032,
-		modtime: 1466180793,
+		modtime: 1476325139,
 		compressed: `
-H4sIAAAJbogA/6RSPU/zMBDe8ytOacc39TswdWViQAxULIjBJOfkqsYOPoNUVf3v+KMujsoAdMyTez7u
-8R0qgLpDbi1Njoyu11A/TKhvjXaSNFq4G2WPcC81KWQHjxO2pKiVcfpfoC+5HXCUgTo4N62F2LLRTUJX
-xvais1K55v+NSNgi8ajLFPYc413b7MqRlqYFhQRiPCVIXLefMLDN6xbbEzZZr2EdIfs/YTGPJYknr5iW
-S/DlzpuBGBThrgNOGyKDGxCiOWRzSHrwkQRBMkgNpB32aGOKKP63zcQ87Fkt75ptIn5Mv+sRO5KbNHG4
-0v9L6+y9tKiCVoeKmzi+Co+7EB4gTaE+LnizaN5TUV/mymohDWrX5EcwNqrO6Tu593FLei5CWiv3RdsO
-x3Lup0beamYotTYu3jVfX2azI99oKfm7TktmlbPGpLXFt3eyGGI9f3flF5cxf495vf7jpTpWnwEAAP//
+H4sIAAAJbogA/6RSvW7jMAze/RSEk/Ec3XCT15tuOHRo0KXooNqUzSCWVFItEAR590JSlNpIh7ZZKX6/
+4rECqHuUjskHcrZuob7zaP86GzRZZPg36QHhv7ZkUALce+zIUKfT9q8IX0s34qQjdAzBt0rtxNkmTzeO
+B9WzNqH5/Ufl2SrjqC8QaZVyHm1XVCXB8rai6EBNZwcZGw4eI9o977A7zzw7jxwIpW4hBgOoM8UDsuRw
+eXydeTuSgCHc9yA5IQqEESGJQxGHzAdvmRC0gLZANuCAnFwk8p8lU0uzF7aStcik+Sk/1xP2pLd543ij
+/gfXRXvNaCJXj0aatL6Jn7tSPRqyFOuTGW5hrXPW0DD3VdiiG7ShKZ/gOLEu4Xt9QJY5vBShmfVh1nbA
+ab73VSGA00JQW+tCumu5vcxmTxLUnPJ7nc6RVfGanNaML6/EGG09fnblV5ex/I9lvRXAU3Wq3gMAAP//
 X3p8DwgEAAA=
 `,
 	},
@@ -300,15 +301,14 @@ X3p8DwgEAAA=
 	"/manifest-list-schema.json": {
 		local:   "manifest-list-schema.json",
 		size:    1010,
-		modtime: 1466180793,
+		modtime: 1476325139,
 		compressed: `
-H4sIAAAJbogA/6ySMU/7MBDF93yKU9rxn/o/MHWFBQnEQMWCGExyaa5q7OAzSFXV747tS0qiMIDoUqkv
-fu9+7+xjBpBXyKWjzpM1+Rryhw7NtTVek0EHt63eItxrQzWyhzsKP48dllRTqZPlX8xYctlgq6O/8b5b
-K7VjawpRV9ZtVeV07Yv/V0q0hfioGiwcPDaMLofRnGxyWlHEUG2PUewDhgT4Q4cxwr7usOy1zoUg5wk5
-fIkVgyY5TyFWaoo8b79piKEm3FfAUhMZfIOQCGBCABIKH5IKmkEbIONxiy6hpAl/6Kim2OfIofUwK+kn
-+Zy3WJHeyInjJSC+As8AS4d1DKyw5iJ5VvHCFyoIZChuk0e+KV8fzmO+oZF2Th9Gu/PYjs/9eHQ/46a/
-XdvvKFBMWLQx1qd3zJfa1jjyd/saO7OBNZHmDt/eyWHEev7uQc+ufrbr8P8lO2WfAQAA//+46c2u8gMA
-AA==
+H4sIAAAJbogA/6ySMU/7MBDF93yKU9rxn/o/MGWFBQnEQMWCGExybq5qbOM7kKqq3x3ZTkqiMoDoevF7
+93vvcigAyha5CeSFnC1rKB882mtnRZPFALe93iDca0sGWeCOWODRY0OGGp0k/6LHkpsOex31nYivldqy
+s1WerlzYqDZoI9X/K5Vni6yjdpRwrZTzaJtxNSdZfq0oYqh+wKh2xJINZO8xWrjXLTbDzAfnMQghlzXE
+iABl9nnCwDlmHp+nX3fEYAh3LXCOiQzSISQCmBFANoWP7AqaQVsgK7jBkFDShj9kVHPsk+WYetyV5sf8
+ueyxJb3OLw6XgPgyPAEsA5po2KLhKmlW8eAL1aIhS7FNnujmfIM5T/nGRDoEvZ90J9hP3/149bDjZriu
+GzoCOM5YtLVO0n/Ml2pravm7vqbKYmRNpGXAt3cKGLGev/uhz05/1nUB8FIci88AAAD//7jpza7yAwAA
 `,
 	},
 

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
@@ -17,34 +17,34 @@ package v1
 // ImageConfig defines the execution parameters which should be used as a base when running a container using an image.
 type ImageConfig struct {
 	// User defines the username or UID which the process in the container should run as.
-	User string `json:"User"`
+	User string `json:"User,omitempty"`
 
 	// Memory defines the memory limit.
-	Memory int64 `json:"Memory"`
+	Memory int64 `json:"Memory,omitempty"`
 
 	// MemorySwap defines the total memory usage limit (memory + swap).
-	MemorySwap int64 `json:"MemorySwap"`
+	MemorySwap int64 `json:"MemorySwap,omitempty"`
 
 	// CPUShares is the CPU shares (relative weight vs. other containers).
-	CPUShares int64 `json:"CpuShares"`
+	CPUShares int64 `json:"CpuShares,omitempty"`
 
 	// ExposedPorts a set of ports to expose from a container running this image.
-	ExposedPorts map[string]struct{} `json:"ExposedPorts"`
+	ExposedPorts map[string]struct{} `json:"ExposedPorts,omitempty"`
 
 	// Env is a list of environment variables to be used in a container.
-	Env []string `json:"Env"`
+	Env []string `json:"Env,omitempty"`
 
 	// Entrypoint defines a list of arguments to use as the command to execute when the container starts.
-	Entrypoint []string `json:"Entrypoint"`
+	Entrypoint []string `json:"Entrypoint,omitempty"`
 
 	// Cmd defines the default arguments to the entrypoint of the container.
-	Cmd []string `json:"Cmd"`
+	Cmd []string `json:"Cmd,omitempty"`
 
 	// Volumes is a set of directories which should be created as data volumes in a container running this image.
-	Volumes map[string]struct{} `json:"Volumes"`
+	Volumes map[string]struct{} `json:"Volumes,omitempty"`
 
 	// WorkingDir sets the current working directory of the entrypoint process in the container.
-	WorkingDir string `json:"WorkingDir"`
+	WorkingDir string `json:"WorkingDir,omitempty"`
 }
 
 // RootFS describes a layer content addresses
@@ -59,28 +59,28 @@ type RootFS struct {
 // History describes the history of a layer.
 type History struct {
 	// Created is the creation time.
-	Created string `json:"created"`
+	Created string `json:"created,omitempty"`
 
 	// CreatedBy is the command which created the layer.
-	CreatedBy string `json:"created_by"`
+	CreatedBy string `json:"created_by,omitempty"`
 
 	// Author is the author of the build point.
-	Author string `json:"author"`
+	Author string `json:"author,omitempty"`
 
 	// Comment is a custom message set when creating the layer.
-	Comment string `json:"comment"`
+	Comment string `json:"comment,omitempty"`
 
 	// EmptyLayer is used to mark if the history item created a filesystem diff.
-	EmptyLayer bool `json:"empty_layer"`
+	EmptyLayer bool `json:"empty_layer,omitempty"`
 }
 
 // Image is the JSON structure which describes some basic information about the image.
 type Image struct {
 	// Created defines an ISO-8601 formatted combined date and time at which the image was created.
-	Created string `json:"created"`
+	Created string `json:"created,omitempty"`
 
 	// Author defines the name and/or email address of the person or entity which created and is responsible for maintaining the image.
-	Author string `json:"author"`
+	Author string `json:"author,omitempty"`
 
 	// Architecture is the CPU architecture which the binaries in this image are built to run on.
 	Architecture string `json:"architecture"`
@@ -89,11 +89,11 @@ type Image struct {
 	OS string `json:"os"`
 
 	// Config defines the execution parameters which should be used as a base when running a container using the image.
-	Config ImageConfig `json:"config"`
+	Config ImageConfig `json:"config,omitempty"`
 
 	// RootFS references the layer content addresses used by the image.
 	RootFS RootFS `json:"rootfs"`
 
 	// History describes the history of each layer.
-	History []History `json:"history"`
+	History []History `json:"history,omitempty"`
 }

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package specs
+package v1
 
 // Descriptor describes the disposition of targeted content.
 type Descriptor struct {

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/layout.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/layout.go
@@ -12,21 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package specs
+package v1
 
-import "fmt"
-
-const (
-	// VersionMajor is for an API incompatible changes
-	VersionMajor = 1
-	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 0
-	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
-
-	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc1-dev"
-)
-
-// Version is the specification version that the package types support.
-var Version = fmt.Sprintf("%d.%d.%d%s", VersionMajor, VersionMinor, VersionPatch, VersionDev)
+// ImageLayout is the structure in the "oci-layout" file, found in the root
+// of an OCI Image-layout directory.
+type ImageLayout struct {
+	Version string `json:"imageLayoutVersion"`
+}

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
@@ -22,11 +22,11 @@ type Manifest struct {
 
 	// Config references a configuration object for a container, by digest.
 	// The referenced configuration object is a JSON blob that the runtime uses to set up the container.
-	Config specs.Descriptor `json:"config"`
+	Config Descriptor `json:"config"`
 
 	// Layers is an indexed list of layers referenced by the manifest.
-	Layers []specs.Descriptor `json:"layers"`
+	Layers []Descriptor `json:"layers"`
 
 	// Annotations contains arbitrary metadata for the manifest list.
-	Annotations map[string]string `json:"annotations"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest_list.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest_list.go
@@ -44,7 +44,7 @@ type Platform struct {
 
 // ManifestDescriptor describes a platform specific manifest.
 type ManifestDescriptor struct {
-	specs.Descriptor
+	Descriptor
 
 	// Platform describes the platform which the image in the manifest runs on.
 	Platform Platform `json:"platform"`
@@ -58,5 +58,5 @@ type ManifestList struct {
 	Manifests []ManifestDescriptor `json:"manifests"`
 
 	// Annotations contains arbitrary metadata for the manifest list.
-	Annotations map[string]string `json:"annotations"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
@@ -25,11 +25,11 @@ const (
 	MediaTypeImageManifestList = "application/vnd.oci.image.manifest.list.v1+json"
 
 	// MediaTypeImageLayer is the media type used for layers referenced by the manifest.
-	MediaTypeImageLayer = "application/vnd.oci.image.layer.tar+gzip"
+	MediaTypeImageLayer = "application/vnd.oci.image.layer.v1.tar+gzip"
 
 	// MediaTypeImageLayerNonDistributable is the media type for layers referenced by
 	// the manifest but with distribution restrictions.
-	MediaTypeImageLayerNonDistributable = "application/vnd.oci.image.layer.nondistributable.tar+gzip"
+	MediaTypeImageLayerNonDistributable = "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip"
 
 	// MediaTypeImageConfig specifies the media type for the image configuration.
 	MediaTypeImageConfig = "application/vnd.oci.image.config.v1+json"

--- a/vendor/github.com/opencontainers/image-spec/specs-go/versioned.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/versioned.go
@@ -22,5 +22,5 @@ type Versioned struct {
 	SchemaVersion int `json:"schemaVersion"`
 
 	// MediaType is the media type of this schema.
-	MediaType string `json:"mediaType,omitempty"`
+	MediaType string `json:"mediaType"`
 }

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -4,27 +4,27 @@ import "os"
 
 // Spec is the base configuration for the container.
 type Spec struct {
-	// Version is the version of the specification that is supported.
+	// Version of the Open Container Runtime Specification with which the bundle complies.
 	Version string `json:"ociVersion"`
-	// Platform is the host information for OS and Arch.
+	// Platform specifies the configuration's target platform.
 	Platform Platform `json:"platform"`
-	// Process is the container's main process.
+	// Process configures the container process.
 	Process Process `json:"process"`
-	// Root is the root information for the container's filesystem.
+	// Root configures the container's root filesystem.
 	Root Root `json:"root"`
-	// Hostname is the container's host name.
+	// Hostname configures the container's hostname.
 	Hostname string `json:"hostname,omitempty"`
-	// Mounts profile configuration for adding mounts to the container's filesystem.
+	// Mounts configures additional mounts (on top of Root).
 	Mounts []Mount `json:"mounts,omitempty"`
-	// Hooks are the commands run at various lifecycle events of the container.
+	// Hooks configures callbacks for container lifecycle events.
 	Hooks Hooks `json:"hooks"`
-	// Annotations is an unstructured key value map that may be set by external tools to store and retrieve arbitrary metadata.
+	// Annotations contains arbitrary metadata for the container.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// Linux is platform specific configuration for Linux based containers.
-	Linux Linux `json:"linux" platform:"linux,omitempty"`
+	Linux *Linux `json:"linux,omitempty" platform:"linux"`
 	// Solaris is platform specific configuration for Solaris containers.
-	Solaris Solaris `json:"solaris" platform:"solaris,omitempty"`
+	Solaris *Solaris `json:"solaris,omitempty" platform:"solaris"`
 }
 
 // Process contains information to start a specific application inside the container.
@@ -47,21 +47,21 @@ type Process struct {
 	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
 	NoNewPrivileges bool `json:"noNewPrivileges,omitempty"`
 
-	// ApparmorProfile specified the apparmor profile for the container. (this field is platform dependent)
+	// ApparmorProfile specifies the apparmor profile for the container. (this field is platform dependent)
 	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
 	// SelinuxLabel specifies the selinux context that the container process is run as. (this field is platform dependent)
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 }
 
-// User specifies Linux specific user and group information for the container's
-// main process.
+// User specifies Linux/Solaris specific user and group information
+// for the container process.
 type User struct {
 	// UID is the user id. (this field is platform dependent)
-	UID uint32 `json:"uid" platform:"linux"`
+	UID uint32 `json:"uid" platform:"linux,solaris"`
 	// GID is the group id. (this field is platform dependent)
-	GID uint32 `json:"gid" platform:"linux"`
+	GID uint32 `json:"gid" platform:"linux,solaris"`
 	// AdditionalGids are additional group ids set for the container's process. (this field is platform dependent)
-	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux"`
+	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux,solaris"`
 }
 
 // Root contains information about the container's root filesystem on the host.
@@ -262,7 +262,7 @@ type Memory struct {
 	// Kernel memory limit (in bytes).
 	Kernel *uint64 `json:"kernel,omitempty"`
 	// Kernel memory limit for tcp (in bytes)
-	KernelTCP *uint64 `json:"kernelTCP"`
+	KernelTCP *uint64 `json:"kernelTCP,omitempty"`
 	// How aggressive the kernel will swap memory pages. Range from 0 to 100.
 	Swappiness *uint64 `json:"swappiness,omitempty"`
 }
@@ -294,15 +294,15 @@ type Pids struct {
 // Network identification and priority configuration
 type Network struct {
 	// Set class identifier for container's network packets
-	ClassID *uint32 `json:"classID"`
+	ClassID *uint32 `json:"classID,omitempty"`
 	// Set priority of network traffic for container
 	Priorities []InterfacePriority `json:"priorities,omitempty"`
 }
 
 // Resources has container runtime resource constraints
 type Resources struct {
-	// Devices are a list of device rules for the whitelist controller
-	Devices []DeviceCgroup `json:"devices"`
+	// Devices configures the device whitelist.
+	Devices []DeviceCgroup `json:"devices,omitempty"`
 	// DisableOOMKiller disables the OOM killer for out of memory conditions
 	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
 	// Specify an oom_score_adj for the container.
@@ -371,9 +371,9 @@ type Solaris struct {
 	// Specification for automatic creation of network resources for this container.
 	Anet []Anet `json:"anet,omitempty"`
 	// Set limit on the amount of CPU time that can be used by container.
-	CappedCPU CappedCPU `json:"cappedCPU,omitempty"`
+	CappedCPU *CappedCPU `json:"cappedCPU,omitempty"`
 	// The physical and swap caps on the memory that can be used by this container.
-	CappedMemory CappedMemory `json:"cappedMemory,omitempty"`
+	CappedMemory *CappedMemory `json:"cappedMemory,omitempty"`
 }
 
 // CappedCPU allows users to set limit on the amount of CPU time that can be used by container.

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
@@ -8,7 +8,7 @@ type State struct {
 	ID string `json:"id"`
 	// Status is the runtime state of the container.
 	Status string `json:"status"`
-	// Pid is the process id for the container's main process.
+	// Pid is the process ID for the container process.
 	Pid int `json:"pid"`
 	// BundlePath is the path to the container's bundle directory.
 	BundlePath string `json:"bundlePath"`

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc1"
+	VersionDev = "-rc2"
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/github.com/spf13/pflag/bool.go
+++ b/vendor/github.com/spf13/pflag/bool.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // optional interface to indicate boolean flags that can be
 // supplied without "=value" text
@@ -30,7 +27,7 @@ func (b *boolValue) Type() string {
 	return "bool"
 }
 
-func (b *boolValue) String() string { return fmt.Sprintf("%v", *b) }
+func (b *boolValue) String() string { return strconv.FormatBool(bool(*b)) }
 
 func (b *boolValue) IsBoolFlag() bool { return true }
 

--- a/vendor/github.com/spf13/pflag/count.go
+++ b/vendor/github.com/spf13/pflag/count.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- count Value
 type countValue int
@@ -28,7 +25,7 @@ func (i *countValue) Type() string {
 	return "count"
 }
 
-func (i *countValue) String() string { return fmt.Sprintf("%v", *i) }
+func (i *countValue) String() string { return strconv.Itoa(int(*i)) }
 
 func countConv(sval string) (interface{}, error) {
 	i, err := strconv.Atoi(sval)

--- a/vendor/github.com/spf13/pflag/flag.go
+++ b/vendor/github.com/spf13/pflag/flag.go
@@ -416,7 +416,7 @@ func Set(name, value string) error {
 // otherwise, the default values of all defined flags in the set.
 func (f *FlagSet) PrintDefaults() {
 	usages := f.FlagUsages()
-	fmt.Fprintf(f.out(), "%s", usages)
+	fmt.Fprint(f.out(), usages)
 }
 
 // defaultIsZeroValue returns true if the default value for this flag represents
@@ -514,7 +514,7 @@ func (f *FlagSet) FlagUsages() string {
 		if len(flag.NoOptDefVal) > 0 {
 			switch flag.Value.Type() {
 			case "string":
-				line += fmt.Sprintf("[=%q]", flag.NoOptDefVal)
+				line += fmt.Sprintf("[=\"%s\"]", flag.NoOptDefVal)
 			case "bool":
 				if flag.NoOptDefVal != "true" {
 					line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
@@ -534,7 +534,7 @@ func (f *FlagSet) FlagUsages() string {
 		line += usage
 		if !flag.defaultIsZeroValue() {
 			if flag.Value.Type() == "string" {
-				line += fmt.Sprintf(" (default %q)", flag.DefValue)
+				line += fmt.Sprintf(" (default \"%s\")", flag.DefValue)
 			} else {
 				line += fmt.Sprintf(" (default %s)", flag.DefValue)
 			}

--- a/vendor/github.com/spf13/pflag/float32.go
+++ b/vendor/github.com/spf13/pflag/float32.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- float32 Value
 type float32Value float32
@@ -23,7 +20,7 @@ func (f *float32Value) Type() string {
 	return "float32"
 }
 
-func (f *float32Value) String() string { return fmt.Sprintf("%v", *f) }
+func (f *float32Value) String() string { return strconv.FormatFloat(float64(*f), 'g', -1, 32) }
 
 func float32Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseFloat(sval, 32)

--- a/vendor/github.com/spf13/pflag/float64.go
+++ b/vendor/github.com/spf13/pflag/float64.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- float64 Value
 type float64Value float64
@@ -23,7 +20,7 @@ func (f *float64Value) Type() string {
 	return "float64"
 }
 
-func (f *float64Value) String() string { return fmt.Sprintf("%v", *f) }
+func (f *float64Value) String() string { return strconv.FormatFloat(float64(*f), 'g', -1, 64) }
 
 func float64Conv(sval string) (interface{}, error) {
 	return strconv.ParseFloat(sval, 64)

--- a/vendor/github.com/spf13/pflag/int.go
+++ b/vendor/github.com/spf13/pflag/int.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- int Value
 type intValue int
@@ -23,7 +20,7 @@ func (i *intValue) Type() string {
 	return "int"
 }
 
-func (i *intValue) String() string { return fmt.Sprintf("%v", *i) }
+func (i *intValue) String() string { return strconv.Itoa(int(*i)) }
 
 func intConv(sval string) (interface{}, error) {
 	return strconv.Atoi(sval)

--- a/vendor/github.com/spf13/pflag/int32.go
+++ b/vendor/github.com/spf13/pflag/int32.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- int32 Value
 type int32Value int32
@@ -23,7 +20,7 @@ func (i *int32Value) Type() string {
 	return "int32"
 }
 
-func (i *int32Value) String() string { return fmt.Sprintf("%v", *i) }
+func (i *int32Value) String() string { return strconv.FormatInt(int64(*i), 10) }
 
 func int32Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseInt(sval, 0, 32)

--- a/vendor/github.com/spf13/pflag/int64.go
+++ b/vendor/github.com/spf13/pflag/int64.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- int64 Value
 type int64Value int64
@@ -23,7 +20,7 @@ func (i *int64Value) Type() string {
 	return "int64"
 }
 
-func (i *int64Value) String() string { return fmt.Sprintf("%v", *i) }
+func (i *int64Value) String() string { return strconv.FormatInt(int64(*i), 10) }
 
 func int64Conv(sval string) (interface{}, error) {
 	return strconv.ParseInt(sval, 0, 64)

--- a/vendor/github.com/spf13/pflag/int8.go
+++ b/vendor/github.com/spf13/pflag/int8.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- int8 Value
 type int8Value int8
@@ -23,7 +20,7 @@ func (i *int8Value) Type() string {
 	return "int8"
 }
 
-func (i *int8Value) String() string { return fmt.Sprintf("%v", *i) }
+func (i *int8Value) String() string { return strconv.FormatInt(int64(*i), 10) }
 
 func int8Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseInt(sval, 0, 8)

--- a/vendor/github.com/spf13/pflag/string.go
+++ b/vendor/github.com/spf13/pflag/string.go
@@ -1,7 +1,5 @@
 package pflag
 
-import "fmt"
-
 // -- string Value
 type stringValue string
 
@@ -18,7 +16,7 @@ func (s *stringValue) Type() string {
 	return "string"
 }
 
-func (s *stringValue) String() string { return fmt.Sprintf("%s", *s) }
+func (s *stringValue) String() string { return string(*s) }
 
 func stringConv(sval string) (interface{}, error) {
 	return sval, nil

--- a/vendor/github.com/spf13/pflag/string_array.go
+++ b/vendor/github.com/spf13/pflag/string_array.go
@@ -2,7 +2,6 @@ package pflag
 
 import (
 	"fmt"
-	"strings"
 )
 
 var _ = fmt.Fprint
@@ -40,7 +39,7 @@ func (s *stringArrayValue) String() string {
 }
 
 func stringArrayConv(sval string) (interface{}, error) {
-	sval = strings.Trim(sval, "[]")
+	sval = sval[1 : len(sval)-1]
 	// An empty string would cause a array with one (empty) string
 	if len(sval) == 0 {
 		return []string{}, nil

--- a/vendor/github.com/spf13/pflag/string_slice.go
+++ b/vendor/github.com/spf13/pflag/string_slice.go
@@ -66,7 +66,7 @@ func (s *stringSliceValue) String() string {
 }
 
 func stringSliceConv(sval string) (interface{}, error) {
-	sval = strings.Trim(sval, "[]")
+	sval = sval[1 : len(sval)-1]
 	// An empty string would cause a slice with one (empty) string
 	if len(sval) == 0 {
 		return []string{}, nil

--- a/vendor/github.com/spf13/pflag/uint.go
+++ b/vendor/github.com/spf13/pflag/uint.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- uint Value
 type uintValue uint
@@ -23,7 +20,7 @@ func (i *uintValue) Type() string {
 	return "uint"
 }
 
-func (i *uintValue) String() string { return fmt.Sprintf("%v", *i) }
+func (i *uintValue) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func uintConv(sval string) (interface{}, error) {
 	v, err := strconv.ParseUint(sval, 0, 0)

--- a/vendor/github.com/spf13/pflag/uint16.go
+++ b/vendor/github.com/spf13/pflag/uint16.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- uint16 value
 type uint16Value uint16
@@ -12,7 +9,7 @@ func newUint16Value(val uint16, p *uint16) *uint16Value {
 	*p = val
 	return (*uint16Value)(p)
 }
-func (i *uint16Value) String() string { return fmt.Sprintf("%d", *i) }
+
 func (i *uint16Value) Set(s string) error {
 	v, err := strconv.ParseUint(s, 0, 16)
 	*i = uint16Value(v)
@@ -22,6 +19,8 @@ func (i *uint16Value) Set(s string) error {
 func (i *uint16Value) Type() string {
 	return "uint16"
 }
+
+func (i *uint16Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func uint16Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseUint(sval, 0, 16)

--- a/vendor/github.com/spf13/pflag/uint32.go
+++ b/vendor/github.com/spf13/pflag/uint32.go
@@ -1,18 +1,15 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
-// -- uint16 value
+// -- uint32 value
 type uint32Value uint32
 
 func newUint32Value(val uint32, p *uint32) *uint32Value {
 	*p = val
 	return (*uint32Value)(p)
 }
-func (i *uint32Value) String() string { return fmt.Sprintf("%d", *i) }
+
 func (i *uint32Value) Set(s string) error {
 	v, err := strconv.ParseUint(s, 0, 32)
 	*i = uint32Value(v)
@@ -22,6 +19,8 @@ func (i *uint32Value) Set(s string) error {
 func (i *uint32Value) Type() string {
 	return "uint32"
 }
+
+func (i *uint32Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func uint32Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseUint(sval, 0, 32)

--- a/vendor/github.com/spf13/pflag/uint64.go
+++ b/vendor/github.com/spf13/pflag/uint64.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- uint64 Value
 type uint64Value uint64
@@ -23,7 +20,7 @@ func (i *uint64Value) Type() string {
 	return "uint64"
 }
 
-func (i *uint64Value) String() string { return fmt.Sprintf("%v", *i) }
+func (i *uint64Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func uint64Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseUint(sval, 0, 64)

--- a/vendor/github.com/spf13/pflag/uint8.go
+++ b/vendor/github.com/spf13/pflag/uint8.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- uint8 Value
 type uint8Value uint8
@@ -23,7 +20,7 @@ func (i *uint8Value) Type() string {
 	return "uint8"
 }
 
-func (i *uint8Value) String() string { return fmt.Sprintf("%v", *i) }
+func (i *uint8Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func uint8Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseUint(sval, 0, 8)


### PR DESCRIPTION
Since https://github.com/opencontainers/image-spec/pull/347 the layer media type has been changed. This commit bumps the image-spec and dependencies.
