### PR TITLE
.pullapprove.yml: Change "image-spec-maintainers" -> "image-tools-maintainers"

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -6,6 +6,6 @@ signed_off_by:
   required: true
 reviewers:
   teams:
-  - image-spec-maintainers
+  - image-tools-maintainers
   name: default
   required: 2


### PR DESCRIPTION
Now that this is an independent project.

I'm guessing at the team name, but it matches the [pattern @caniszczyk used for runtime-tools][1].

[1]: https://github.com/opencontainers/runtime-tools/issues/237#issuecomment-255412514