### PR TITLE
Add regular expression match for ref string input

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -66,6 +66,12 @@ func validate(w walker, refs []string, out *log.Logger) error {
 		}
 	}
 
+	for _, refName := range refs {
+		if err = refsNameRegexpCheck(refName); err != nil {
+			return err
+		}
+	}
+
 	for _, ref := range refs {
 		d, ok := ds[ref]
 		if !ok {
@@ -115,6 +121,10 @@ func Unpack(tarFile, dest, ref string) error {
 }
 
 func unpack(w walker, dest, refName string) error {
+	if err := refsNameRegexpCheck(refName); err != nil {
+		return err
+	}
+
 	ref, err := findDescriptor(w, refName)
 	if err != nil {
 		return err
@@ -157,6 +167,10 @@ func CreateRuntimeBundle(tarFile, dest, ref, root string) error {
 }
 
 func createRuntimeBundle(w walker, dest, refName, rootfs string) error {
+	if err := refsNameRegexpCheck(refName); err != nil {
+		return err
+	}
+
 	ref, err := findDescriptor(w, refName)
 	if err != nil {
 		return err
@@ -197,4 +211,11 @@ func createRuntimeBundle(w walker, dest, refName, rootfs string) error {
 	defer f.Close()
 
 	return json.NewEncoder(f).Encode(spec)
+}
+
+func refsNameRegexpCheck(refName string) error {
+	if boolRefsNameMatch := v1.RefsRegexp.MatchString(refName); !boolRefsNameMatch {
+		return fmt.Errorf("input parameter --ref (%s) is invalide", refName)
+	}
+	return nil
 }


### PR DESCRIPTION
implementation for spec description "Object names in the refs
subdirectories MUST NOT include characters outside of the set of "A" to
"Z", "a" to "z", "0" to "9", the hyphen -, the dot ., and the underscore
_." at https://github.com/opencontainers/image-spec/blob/master/image-layout.md.

Signed-off-by: Ling FaKe lingfake@huawei.com
