### PR TITLE
Modify the automatic determination of the Config type

### DIFF
--- a/image/autodetect.go
+++ b/image/autodetect.go
@@ -79,8 +79,8 @@ func Autodetect(path string) (string, error) {
 
 	header := struct {
 		SchemaVersion int         `json:"schemaVersion"`
-		MediaType     string      `json:"mediaType"`
 		Config        interface{} `json:"config"`
+		Manifests     interface{} `json:"manifests"`
 	}{}
 
 	if err := json.NewDecoder(f).Decode(&header); err != nil {
@@ -97,13 +97,13 @@ func Autodetect(path string) (string, error) {
 	}
 
 	switch {
-	case header.MediaType == string(schema.ValidatorMediaTypeManifest):
+	case header.SchemaVersion == 2 && header.Config != nil:
 		return TypeManifest, nil
 
-	case header.MediaType == string(schema.ValidatorMediaTypeImageIndex):
+	case header.Manifests != nil:
 		return TypeImageIndex, nil
 
-	case header.MediaType == "" && header.SchemaVersion == 0 && header.Config != nil:
+	case header.SchemaVersion == 0 && header.Config != nil:
 		// config files don't have mediaType/schemaVersion header
 		return TypeConfig, nil
 	}


### PR DESCRIPTION
The Config attribute may be empty, so cannot be used as the basis for judging the Config type, should use the RootFS is inevitable in this attribute to judge .
Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>