### PR TITLE
descriptor: size verification should be before digest calculation

### DIFF
--- a/image/descriptor.go
+++ b/image/descriptor.go
@@ -122,14 +122,14 @@ func (d *descriptor) validateContent(r io.Reader) error {
 		return errors.Wrap(err, "error generating hash")
 	}
 
+	if n != d.Size {
+		return errors.New("size mismatch")
+	}
+
 	digest := "sha256:" + hex.EncodeToString(h.Sum(nil))
 
 	if digest != d.Digest {
 		return errors.New("digest mismatch")
-	}
-
-	if n != d.Size {
-		return errors.New("size mismatch")
 	}
 
 	return nil


### PR DESCRIPTION
Conforming to description 'Before calculating the digest, the size of the content SHOULD be
verified to reduce hash collision space.' at https://github.com/opencontainers/image-spec/blob/master/descriptor.md.

Signed-off-by: Ling FaKe <lingfake@huawei.com>