### PR TITLE
omit error for unimplemented unpacking types

### DIFF
--- a/cmd/oci-unpack/main.go
+++ b/cmd/oci-unpack/main.go
@@ -117,6 +117,9 @@ func (v *unpackCmd) Run(cmd *cobra.Command, args []string) {
 
 	case image.TypeImage:
 		err = image.Unpack(args[0], args[1], v.ref)
+	default:
+		v.stderr.Printf("type %q unimplemented", v.typ)
+		os.Exit(1)
 	}
 
 	if err != nil {


### PR DESCRIPTION
For unimplemented(so far) unpacking types, it should omit error message, and return failed result.
Signed-off-by: xiekeyang <xiekeyang@huawei.com>