### PR TITLE
Bump up runtime-spec/image-spec to the latest version

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,16 +1,16 @@
-hash: 14550151b754f92de80e864f26da93e8adfce71537c9cb7883b0bdd67e541453
-updated: 2016-09-15T10:25:30.038113538+02:00
+hash: aece9eb70162cb48739e60c1f0592731ce1a9b635b0ce17f3a68365db5a2544a
+updated: 2016-11-03T11:32:40.340825945+08:00
 imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/opencontainers/image-spec
-  version: 7e6e2f76d6a11cdcb3f3e334e3f12179a0f37dad
+  version: 6e820ec55259e89ccd7092f3131c63e8419a349b
   subpackages:
   - schema
-  - specs-go/v1
   - specs-go
+  - specs-go/v1
 - name: github.com/opencontainers/runtime-spec
-  version: 06479209bdc0d4135911688c18157bd39bd99c22
+  version: 7dab1a245d3e13d0ad03b77409d0bf7e00a6ada4
   subpackages:
   - specs-go
 - name: github.com/pkg/errors
@@ -26,7 +26,7 @@ imports:
 - name: github.com/xeipuuv/gojsonschema
   version: d5336c75940ef31c9ceeb0ae64cf92944bccb4ee
 - name: go4.org
-  version: e7a2449258501866491620d4f47472e6100ca551
+  version: 399a9d7bfe85437346a5ec4ef0450fc2f1084e61
   subpackages:
   - errorutil
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,14 +1,17 @@
 package: github.com/opencontainers/image-tools
 import:
 - package: github.com/opencontainers/image-spec
-  version: 7e6e2f76d6a11cdcb3f3e334e3f12179a0f37dad
+  version: v1.0.0-rc2
   subpackages:
   - schema
   - specs-go/v1
 - package: github.com/opencontainers/runtime-spec
-  version: ~1.0.0-rc1
+  version: v1.0.0-rc2
   subpackages:
   - specs-go
 - package: github.com/pkg/errors
   version: ~0.7.1
 - package: github.com/spf13/cobra
+  version: 9c28e4bbd74e5c3ed7aacbc552b2cab7cfdfe744
+- package: github.com/spf13/pflag
+  version: 7b17cc4658ef5ca157b986ea5c0b43af7938532b

--- a/image/config.go
+++ b/image/config.go
@@ -116,6 +116,7 @@ func (c *config) runtimeSpec(rootfs string) (*specs.Spec, error) {
 	swap := uint64(c.Config.MemorySwap)
 	shares := uint64(c.Config.CPUShares)
 
+	s.Linux = &specs.Linux{}
 	s.Linux.Resources = &specs.Resources{
 		CPU: &specs.CPU{
 			Shares: &shares,

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -103,7 +103,7 @@ var (
     "layers": [
         {
             "digest": "<layer_digest>",
-            "mediaType": "application/vnd.oci.image.layer.tar+gzip",
+            "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
             "size": <layer_size>
         }
     ],

--- a/image/manifest_test.go
+++ b/image/manifest_test.go
@@ -108,7 +108,7 @@ func TestUnpackLayer(t *testing.T) {
 
 	testManifest := manifest{
 		Layers: []descriptor{descriptor{
-			MediaType: "application/vnd.oci.image.layer.tar+gzip",
+			MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
 			Digest:    fmt.Sprintf("sha256:%s", fmt.Sprintf("%x", h.Sum(nil))),
 		}},
 	}
@@ -169,7 +169,7 @@ func TestUnpackLayerRemovePartialyUnpackedFile(t *testing.T) {
 
 	testManifest := manifest{
 		Layers: []descriptor{descriptor{
-			MediaType: "application/vnd.oci.image.layer.tar+gzip",
+			MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
 			Digest:    fmt.Sprintf("sha256:%s", fmt.Sprintf("%x", h.Sum(nil))),
 		}},
 	}

--- a/vendor/github.com/opencontainers/image-spec/schema/fs.go
+++ b/vendor/github.com/opencontainers/image-spec/schema/fs.go
@@ -205,7 +205,7 @@ var _escData = map[string]*_escFile{
 	"/config-schema.json": {
 		local:   "config-schema.json",
 		size:    710,
-		modtime: 1466466955,
+		modtime: 1473949379,
 		compressed: `
 H4sIAAAJbogA/5SRPW7DMAyFd5/CcDLWUYdOWXuADj2BKlMxA1gUSGYICt+9+olbGygKdzGMx/e9J1Gf
 Tdt2A4hjjIoUunPbvUUIrxTUYgBu05/HS/sewaFHZ4vrKWNHcSNMNiOjajwbcxUKfVVPxBczsPXaP7+Y
@@ -217,56 +217,56 @@ l/9nPbhN1oiixPffrmGZ7f1n3Wk307p0d+1S8eDmZvnOzdx8BQAA//964XeexgIAAA==
 
 	"/content-descriptor.json": {
 		local:   "content-descriptor.json",
-		size:    616,
-		modtime: 1466180793,
+		size:    637,
+		modtime: 1473949379,
 		compressed: `
-H4sIAAAJbogA/4yRMVPDMAyF9/wKXdqR1gxMXWFngI1jcG0lVe9iG1kMhet/x4oTSGGgW/L8vvck+7MB
-aD1mx5SEYmh30D4mDPcxiKWADPqFQeBhMkWGp4SOOnJ2JG40Yp3dAQer+EEk7Yw55hg2Vd1G7o1n28nm
-9s5UbVU58jOSCxNLs5ub84hVt/Hf7ZWTU0Il4/6ITqqWuPAshLmc6GJFG9CTfa7mKv3dVw4Io09DIXag
-AmOHXKZBD4uOEV+XM+U8dnlDg+1xq8uuyj8F0tRsfnpH6lzhNtPHf5OoBSjA/iSYr5hmvgkqz9QjX/Z5
-6jHLsvGa4SeqJjVTWsv49k6M+mAvvy93ud5ldfl5bc7NVwAAAP//Zc2MR2gCAAA=
+H4sIAAAJbogA/5SRMVPDMAyF9/wKXdqR1gw9hq6wM8DGMbi20qh3sY0thsL1v2NFKaQwAFv8rE/vvfi9
+AWg9FpcpMcXQbqG9TxhuY2BLATPIFwaGu2koZnhI6KgjZ0fiSlYsi+txsIL3zGlrzKHEsFJ1HfPe+Gw7
+Xl1vjGoL5cifkVKZWJ3d2bmMmE4b/+muHB8TChl3B3SsWsqVz0xY6o0Uq9qAnuyjDqv0sy/3COOcLIXY
+gQgZO8w1DXqYeYz4st4J57ErKxrsHtdSdlHPFEi2FvPlO1InhdtCb78lkRGgALsjY/lnGs1h5kEo8M3m
+MoSnPRaex/hLo4nSTc20rc348koZ5RWfvv/xeedL63p4bk7NRwAAAP//zGqYSn0CAAA=
 `,
 	},
 
 	"/defs-config.json": {
 		local:   "defs-config.json",
-		size:    2154,
-		modtime: 1466467007,
+		size:    2270,
+		modtime: 1475248413,
 		compressed: `
-H4sIAAAJbogA/+RVzY7TMBC+5ymswLGwF8SB6y5HVKQIOCBUucl4O0vsscYTIEL77jjZquSnCWlLT3uo
-mkz8/cyMPf6dKJUWEHJGL0gufafSOzDosHkLymsWzKtSsxJSaw/ulpxodMAqPhm8V5mHHA3musWvnggP
-DJGw0YjBvF1+eI8RqT00grR9gFxaaBv3TB6iLoTO6hj/FIB7kQ5HEEZ3nx4+Pa7+4j6AJa6HyJcMpkFG
-s+H1QyD34qbj+wadvH0zx5f91P7/cd76KttpHqR8EeX7X54CFB+J5VRWq33WFnT91Jrj/O7HVDc0s67T
-VfcTCtihjZn+RakJUeHaU0x7qE0O1k1OX3sCfblZizM2/2G1b3dgedaFq8qyz9Tl+XZ8q9ji2eb+mcrK
-jg/JwvzP3fXXzuoL8fcoe4fLx1vS/d9zpUwkJlwyYgs0ZoPFqMDXP9ilroEndZflv8Mg/Ul/cgFyBi0w
-OmADH70CGGKrpd1XEfpK0MLxgakr2dFZN9je1WY7usUWoclaGA/MJVCwXupN25sp+JaoBO0me5M0v8fk
-TwAAAP//dkZ6ZWoIAAA=
+H4sIAAAJbogA/+RVzY7TMBC+5yksw7GwF8SB6y5HVKQKOCBUucl4O0vsMeMJEKF9d5xs6cZJG7q79MSh
+ajLx9zMz9vhXoZSuIJaMQZC8fqP0FVj02L1FFQwLlk1tWAmpZQB/SV4MemCVnixeq1WAEi2Wpscv7gj3
+DImw00jBsl++f08RaQN0grS5gVJ6aB8PTAGSLsTB6hT/EIGzyIAjCqO/1vtPt4t73DtwxO0Y+ZzBdshk
+Nr68ieSfXQx8X6CX16/m+FY/TPh3nJehWW0Nj1J+EuXbn4EiVO+J5aGszoRVX9DlXWsO8/vvx7phmE2r
+F8NPKODGNmb6l6SOiAq3gVLaY23ysOxy+pwJ5HKzFmds/sVqbndkedaFb+o6ZxryfDm8VVz13+b+kerG
+TQ/Jifk/dtefO6tPxF+T7BWePt6K4f+OSzOR2PiUEVuhtWusJgU+/8HerZ/LPpMF37hJx3VtWuCoD1e8
+GKlqhm8NMlQZz30Nxu6KIeOfmm8xSn67PLjoJYMRmBzquewtsTPS7+UEfSHo4PCQNo1s6VG35s7VejO5
+OU9Ck3MwHdKnQMEFadd9J4/BN0Q1GH/0PBTd77b4HQAA//9fxiKD3ggAAA==
 `,
 	},
 
 	"/defs-image.json": {
 		local:   "defs-image.json",
-		size:    2528,
-		modtime: 1466438460,
+		size:    2550,
+		modtime: 1473999429,
 		compressed: `
-H4sIAAAJbogA/7RWy27bMBC8+ysIJUAOfqjXGkGAoEGBnlIgPTVQgY20kphKpLqkgzqB/r2k3k+nrt0b
-ueQOZ4Zjym8LxpwAlU8801wKZ8ucOwy54HamWAakub9LgJiW7D5D8UkKDVwgsS8pRMgeMvR5yH0o2lcl
-XgNg8OwRpphiwOHbPsOmZIo8sAfGWmdq67rSwPs1vNpIilzlx5iCy+1RbguxqgF0CegoTVxEbT0DrZEK
-OT8eYf3qLd3HD+uPZnS7/r5ZestLp9ialx1OwCNUukttYIqOkfm0z7SMCLKY+8ww83+qXcrKXiZDZjfJ
-p2f09YpxUUwrIuzqOgYV32yvY/wNgbEshaTqvLk6Xo/R4i23ZhTerj8Xk4GgFAQPDfhdJUPSCb6PsUaE
-S9ltnfDXjhPacx6rWi8Eq7ao+GtvXt1Fp5IloENJqVOVvNYXMuRNRFF15M2kbe5ai71WR32FhCGSsQQD
-NpBVQFyaddt70cl5J5vN1nyo8X0qdptNztNeo/pLOvUNcKExQpo+f5TveSXV1kmY5iIGQMflqUGZ1DGl
-cTJNxQqQH3NtGnaEvR6zJpXTKXg9xJngjDGHq/+s1j1AdfzL7y3nY2Hno2XATiSzeTEnlCk+H6kG9FRy
-IYJ1/LyWtaiz9IAI9uNlk4B0iss7woy0g0JfgDiI4S/8aL8OmfXfhI2gIAiKxwiSr92faQiJwsWcJ+24
-HuW9LyIIITX0/5UcHYEuSPMRkgLvw97TNPnKmkdWbZ6VFBdu78sB2UPhy8PAnY4vb1MPpdgliTMS7S3q
-Wb7IF38CAAD//wKthPngCQAA
+H4sIAAAJbogA/7RWy27bMBC8+ysIJUAOfqiHokCNIEDRXHpKgfTUQC020spiKpEsSQd1Av17l5Kstxy4
+dm/iLnc4MxpTfp0x5kVoQs2V5VJ4a+bdYswFdyvDFGjLw20KmlnJ7hSKz1JY4AI1+5LBBtm9wpDHPIRi
+fFHi1QCE546gYoYRh287hXWJijxyBybWKrP2fUnw4R7erKTe+CZMMAOfu6P8BmKxB7AloGes5mLT1BVY
+i7qQ8+MBli/B3H94t/xIT5+W31fzYH7pFVvzcsKL+AaNbVPrmWITZKHeKSs3GlTCQ0bMwl9mm7FylsmY
+uU3y8QlDu2BcFMuKCLu6TsAkN+vrBP9ARJZlkFaTN1fH6yEtP+erZTBf0yqm1UBRBoLHhH5b6ZD6BOOH
+WAPGpe6mrvH3lmt05zxUtU4KFk3R8JfOunoZrYpKwcZSZ15VChpjNJGnjKJpyZuI29R7LfY6Hft3qDFG
+TZZgxHqyCohL6rvZi1bQW+Gst+Z9jW9TcdtcdB53Fs2RdIiNWT0ZKS78NjEu7If346QGqZ+WV20dhanf
+Tg/ouJDVKB1xE/EqeqMRKzqgw4RbGthq7MxQTxqvVQg6iBNpGmL2u/+s1j9AdXgfdNr5UNj5aBHYiWRW
+z3RCGe3zkapBTyUXIzjHz2tZgzpJD7SG3bBNCcjGuLwhjKQdFPoMmoPo/8KP9uuQWf9N2AAKoqi4jCD9
+2v6ZxpAanE150jzvn/LOZxKEkBa6/1WOjkAbpP4ySYF3cedqGr1lJ27tDNR94ct9z52WL69jF6XYpqk3
+EB3M9qt8ls/+BgAA//9cX80Z9gkAAA==
 `,
 	},
 
 	"/defs.json": {
 		local:   "defs.json",
 		size:    3193,
-		modtime: 1466180793,
+		modtime: 1473949379,
 		compressed: `
 H4sIAAAJbogA/7RWTXPaMBC98ys8tEfa2PIX9NYp/cghAzOZnjo9uGYBtSCpstxpmuG/VzLGWPZiMKWH
 JPau9r23T6tYzwPHGS4gSyUVinI2fOMMp7CkjJq3zMkzWDhqLXm+WvNc6UdwZgLYO85UQhlI51FASpc0
@@ -285,7 +285,7 @@ MrVJbn8cB+ZnN/gbAAD//0JyEpx5DAAA
 	"/image-manifest-schema.json": {
 		local:   "image-manifest-schema.json",
 		size:    1032,
-		modtime: 1466180793,
+		modtime: 1474208561,
 		compressed: `
 H4sIAAAJbogA/6RSPU/zMBDe8ytOacc39TswdWViQAxULIjBJOfkqsYOPoNUVf3v+KMujsoAdMyTez7u
 8R0qgLpDbi1Njoyu11A/TKhvjXaSNFq4G2WPcC81KWQHjxO2pKiVcfpfoC+5HXCUgTo4N62F2LLRTUJX
@@ -300,7 +300,7 @@ X3p8DwgEAAA=
 	"/manifest-list-schema.json": {
 		local:   "manifest-list-schema.json",
 		size:    1010,
-		modtime: 1466180793,
+		modtime: 1473949379,
 		compressed: `
 H4sIAAAJbogA/6ySMU/7MBDF93yKU9rxn/o/MHWFBQnEQMWCGExyaa5q7OAzSFXV747tS0qiMIDoUqkv
 fu9+7+xjBpBXyKWjzpM1+Rryhw7NtTVek0EHt63eItxrQzWyhzsKP48dllRTqZPlX8xYctlgq6O/8b5b

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package specs
+package v1
 
 // Descriptor describes the disposition of targeted content.
 type Descriptor struct {

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
@@ -22,10 +22,10 @@ type Manifest struct {
 
 	// Config references a configuration object for a container, by digest.
 	// The referenced configuration object is a JSON blob that the runtime uses to set up the container.
-	Config specs.Descriptor `json:"config"`
+	Config Descriptor `json:"config"`
 
 	// Layers is an indexed list of layers referenced by the manifest.
-	Layers []specs.Descriptor `json:"layers"`
+	Layers []Descriptor `json:"layers"`
 
 	// Annotations contains arbitrary metadata for the manifest list.
 	Annotations map[string]string `json:"annotations"`

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest_list.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest_list.go
@@ -44,7 +44,7 @@ type Platform struct {
 
 // ManifestDescriptor describes a platform specific manifest.
 type ManifestDescriptor struct {
-	specs.Descriptor
+	Descriptor
 
 	// Platform describes the platform which the image in the manifest runs on.
 	Platform Platform `json:"platform"`

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
@@ -25,11 +25,11 @@ const (
 	MediaTypeImageManifestList = "application/vnd.oci.image.manifest.list.v1+json"
 
 	// MediaTypeImageLayer is the media type used for layers referenced by the manifest.
-	MediaTypeImageLayer = "application/vnd.oci.image.layer.tar+gzip"
+	MediaTypeImageLayer = "application/vnd.oci.image.layer.v1.tar+gzip"
 
 	// MediaTypeImageLayerNonDistributable is the media type for layers referenced by
 	// the manifest but with distribution restrictions.
-	MediaTypeImageLayerNonDistributable = "application/vnd.oci.image.layer.nondistributable.tar+gzip"
+	MediaTypeImageLayerNonDistributable = "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip"
 
 	// MediaTypeImageConfig specifies the media type for the image configuration.
 	MediaTypeImageConfig = "application/vnd.oci.image.config.v1+json"

--- a/vendor/github.com/opencontainers/image-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/version.go
@@ -18,14 +18,14 @@ import "fmt"
 
 const (
 	// VersionMajor is for an API incompatible changes
-	VersionMajor = 0
+	VersionMajor = 1
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 3
+	VersionMinor = 0
 	// VersionPatch is for backwards-compatible bug fixes
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = "-rc2"
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -4,27 +4,27 @@ import "os"
 
 // Spec is the base configuration for the container.
 type Spec struct {
-	// Version is the version of the specification that is supported.
+	// Version of the Open Container Runtime Specification with which the bundle complies.
 	Version string `json:"ociVersion"`
-	// Platform is the host information for OS and Arch.
+	// Platform specifies the configuration's target platform.
 	Platform Platform `json:"platform"`
-	// Process is the container's main process.
+	// Process configures the container process.
 	Process Process `json:"process"`
-	// Root is the root information for the container's filesystem.
+	// Root configures the container's root filesystem.
 	Root Root `json:"root"`
-	// Hostname is the container's host name.
+	// Hostname configures the container's hostname.
 	Hostname string `json:"hostname,omitempty"`
-	// Mounts profile configuration for adding mounts to the container's filesystem.
+	// Mounts configures additional mounts (on top of Root).
 	Mounts []Mount `json:"mounts,omitempty"`
-	// Hooks are the commands run at various lifecycle events of the container.
+	// Hooks configures callbacks for container lifecycle events.
 	Hooks Hooks `json:"hooks"`
-	// Annotations is an unstructured key value map that may be set by external tools to store and retrieve arbitrary metadata.
+	// Annotations contains arbitrary metadata for the container.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// Linux is platform specific configuration for Linux based containers.
-	Linux Linux `json:"linux" platform:"linux,omitempty"`
+	Linux *Linux `json:"linux,omitempty" platform:"linux"`
 	// Solaris is platform specific configuration for Solaris containers.
-	Solaris Solaris `json:"solaris" platform:"solaris,omitempty"`
+	Solaris *Solaris `json:"solaris,omitempty" platform:"solaris"`
 }
 
 // Process contains information to start a specific application inside the container.
@@ -47,21 +47,21 @@ type Process struct {
 	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
 	NoNewPrivileges bool `json:"noNewPrivileges,omitempty"`
 
-	// ApparmorProfile specified the apparmor profile for the container. (this field is platform dependent)
+	// ApparmorProfile specifies the apparmor profile for the container. (this field is platform dependent)
 	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
 	// SelinuxLabel specifies the selinux context that the container process is run as. (this field is platform dependent)
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 }
 
-// User specifies Linux specific user and group information for the container's
-// main process.
+// User specifies Linux/Solaris specific user and group information
+// for the container process.
 type User struct {
 	// UID is the user id. (this field is platform dependent)
-	UID uint32 `json:"uid" platform:"linux"`
+	UID uint32 `json:"uid" platform:"linux,solaris"`
 	// GID is the group id. (this field is platform dependent)
-	GID uint32 `json:"gid" platform:"linux"`
+	GID uint32 `json:"gid" platform:"linux,solaris"`
 	// AdditionalGids are additional group ids set for the container's process. (this field is platform dependent)
-	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux"`
+	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux,solaris"`
 }
 
 // Root contains information about the container's root filesystem on the host.
@@ -262,7 +262,7 @@ type Memory struct {
 	// Kernel memory limit (in bytes).
 	Kernel *uint64 `json:"kernel,omitempty"`
 	// Kernel memory limit for tcp (in bytes)
-	KernelTCP *uint64 `json:"kernelTCP"`
+	KernelTCP *uint64 `json:"kernelTCP,omitempty"`
 	// How aggressive the kernel will swap memory pages. Range from 0 to 100.
 	Swappiness *uint64 `json:"swappiness,omitempty"`
 }
@@ -294,15 +294,15 @@ type Pids struct {
 // Network identification and priority configuration
 type Network struct {
 	// Set class identifier for container's network packets
-	ClassID *uint32 `json:"classID"`
+	ClassID *uint32 `json:"classID,omitempty"`
 	// Set priority of network traffic for container
 	Priorities []InterfacePriority `json:"priorities,omitempty"`
 }
 
 // Resources has container runtime resource constraints
 type Resources struct {
-	// Devices are a list of device rules for the whitelist controller
-	Devices []DeviceCgroup `json:"devices"`
+	// Devices configures the device whitelist.
+	Devices []DeviceCgroup `json:"devices,omitempty"`
 	// DisableOOMKiller disables the OOM killer for out of memory conditions
 	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
 	// Specify an oom_score_adj for the container.
@@ -371,9 +371,9 @@ type Solaris struct {
 	// Specification for automatic creation of network resources for this container.
 	Anet []Anet `json:"anet,omitempty"`
 	// Set limit on the amount of CPU time that can be used by container.
-	CappedCPU CappedCPU `json:"cappedCPU,omitempty"`
+	CappedCPU *CappedCPU `json:"cappedCPU,omitempty"`
 	// The physical and swap caps on the memory that can be used by this container.
-	CappedMemory CappedMemory `json:"cappedMemory,omitempty"`
+	CappedMemory *CappedMemory `json:"cappedMemory,omitempty"`
 }
 
 // CappedCPU allows users to set limit on the amount of CPU time that can be used by container.

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
@@ -8,7 +8,7 @@ type State struct {
 	ID string `json:"id"`
 	// Status is the runtime state of the container.
 	Status string `json:"status"`
-	// Pid is the process id for the container's main process.
+	// Pid is the process ID for the container process.
 	Pid int `json:"pid"`
 	// BundlePath is the path to the container's bundle directory.
 	BundlePath string `json:"bundlePath"`

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc1"
+	VersionDev = "-rc2"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
[v1.MediaTypeImageLayer ](https://github.com/opencontainers/image-spec/blob/master/specs-go/v1/mediatype.go#L28) in latest image-spec has changed, need to be bumped up to the latest version.

This commit is only focused on bumping the vendored image-spec and runtime-spec to v1.0.0-rc2. `cobra` and `pflag` doesn't tag releases, so I'm pinning this at our currently-vendored commit. I'm not aware of any reason we can't advance this to a later pflag commit, but haven't done enough research to say for sure. 

Signed-off-by: Ye Yin <eyniy@qq.com>