### PR TITLE
image: generate useful config

### DIFF
--- a/image/config.go
+++ b/image/config.go
@@ -73,12 +73,92 @@ func (c *config) runtimeSpec(rootfs string) (*specs.Spec, error) {
 		return nil, fmt.Errorf("%s: unsupported OS", c.OS)
 	}
 
-	var s specs.Spec
-	s.Version = specs.Version
-	// we should at least apply the default spec, otherwise this is totally useless
-	s.Process.Terminal = true
+	// TODO: Get this default from somewhere, rather than hardcoding it here.
+	// runC has a default as well, maybe the two should be consolidated in the
+	// runtime-spec (or in the runtime-tooling)?
+	s := specs.Spec{
+		Version: specs.Version,
+		Platform: specs.Platform{
+			OS:   "unknown",
+			Arch: "unknown",
+		},
+		Process: specs.Process{
+			Terminal: true,
+			Cwd:      "/",
+			Env:      []string{},
+			Args:     []string{},
+			User: specs.User{
+				UID: 0,
+				GID: 0,
+			},
+		},
+		Root: specs.Root{
+			Path:     "rootfs",
+			Readonly: false,
+		},
+		// These are all required by the runtime-spec to be included. The
+		// actual options are from the default runC spec.
+		Mounts: []specs.Mount{
+			{
+				Destination: "/proc",
+				Type:        "proc",
+				Source:      "proc",
+				Options:     nil,
+			},
+			{
+				Destination: "/sys",
+				Type:        "sysfs",
+				Source:      "sysfs",
+				Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+			},
+			{
+				Destination: "/dev",
+				Type:        "tmpfs",
+				Source:      "tmpfs",
+				Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+			},
+			{
+				Destination: "/dev/pts",
+				Type:        "devpts",
+				Source:      "devpts",
+				Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
+			},
+			{
+				Destination: "/dev/shm",
+				Type:        "tmpfs",
+				Source:      "shm",
+				Options:     []string{"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"},
+			},
+		},
+		Linux: &specs.Linux{
+			MaskedPaths: []string{
+				"/proc/kcore",
+				"/proc/latency_stats",
+				"/proc/timer_list",
+				"/proc/timer_stats",
+				"/proc/sched_debug",
+				"/sys/firmware",
+			},
+			ReadonlyPaths: []string{
+				"/proc/asound",
+				"/proc/bus",
+				"/proc/fs",
+				"/proc/irq",
+				"/proc/sys",
+				"/proc/sysrq-trigger",
+			},
+			// We need at least CLONE_NEWNS in order to set up the mounts.
+			// This is also required to make sure we have a sane rootfs setup.
+			Namespaces: []specs.Namespace{
+				{
+					Type: "mount",
+				},
+			},
+		},
+	}
+
+	// Now fill all of the fields.
 	s.Root.Path = rootfs
-	s.Process.Cwd = "/"
 	if c.Config.WorkingDir != "" {
 		s.Process.Cwd = c.Config.WorkingDir
 	}


### PR DESCRIPTION
The previous config generation produced a config which would cause runC
to run the container using the host filesystem (with no namespaces set
up). While we should try to be as agnostic as possible, we don't want to
generate config.json payloads that are known to be bad (and useless).

Fixes #76 

Signed-off-by: Aleksa Sarai <asarai@suse.com>