### PR TITLE
Update makefile: for easy to debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ export GO15VENDOREXPERIMENT
 COMMIT=$(shell git rev-parse HEAD 2> /dev/null || true)
 
 EPOCH_TEST_COMMIT ?= v0.2.0
+GOFLAG=
 TOOLS := \
 	oci-create-runtime-bundle \
 	oci-image-validate \
@@ -14,10 +15,10 @@ default: help
 help:
 	@echo "Usage: make <target>"
 	@echo
-	@echo " * 'tools' - Build the oci image tools binaries"
+	@echo " * 'GOFLAG tools' - Build the oci image tools binaries"
 	@echo " * 'check-license' - Check license headers in source files"
 	@echo " * 'lint' - Execute the source code linter"
-	@echo " * 'test' - Execute the unit tests"
+	@echo " * 'GOFLAG test' - Execute the unit tests"
 	@echo " * 'update-deps' - Update vendored dependencies"
 
 check-license:
@@ -27,14 +28,14 @@ check-license:
 tools: $(TOOLS)
 
 $(TOOLS): oci-%:
-	go build -ldflags "-X main.gitCommit=${COMMIT}" ./cmd/$@
+	go build ${GOFLAG} -ldflags "-X main.gitCommit=${COMMIT}" ./cmd/$@
 
 lint:
 	@echo "checking lint"
 	@./.tool/lint
 
 test:
-	go test -race -cover $(shell go list ./... | grep -v /vendor/)
+	go test -race -cover ${GOFLAG} $(shell go list ./... | grep -v /vendor/)
 
 ## this uses https://github.com/Masterminds/glide and https://github.com/sgotti/glide-vc
 update-deps:


### PR DESCRIPTION
Signed-off-by: Sn0rt <Sn0rt@abc.shop.edu.cn>

It can be easy to debug if Makefile can import GOFLAG environment variable.

**go build flag**
```shell
$ make GOFLAG="-v" tools
go build -v -ldflags "-X main.gitCommit=0a1e5dc0c9b67619d46bd8cbcc948bda1b143b27" ./cmd/oci-create-runtime-bundle
github.com/opencontainers/image-tools/vendor/github.com/opencontainers/image-spec/specs-go
github.com/opencontainers/image-tools/vendor/github.com/pkg/errors
github.com/opencontainers/image-tools/vendor/github.com/xeipuuv/gojsonpointer
github.com/opencontainers/image-tools/vendor/go4.org/errorutil
github.com/opencontainers/image-tools/vendor/github.com/opencontainers/image-spec/specs-go/v1
github.com/opencontainers/image-tools/vendor/github.com/opencontainers/runtime-spec/specs-go
github.com/opencontainers/image-tools/vendor/github.com/xeipuuv/gojsonreference
github.com/opencontainers/image-tools/vendor/github.com/spf13/pflag
github.com/opencontainers/image-tools/vendor/github.com/xeipuuv/gojsonschema
github.com/opencontainers/image-tools/vendor/github.com/spf13/cobra
github.com/opencontainers/image-tools/vendor/github.com/opencontainers/image-spec/schema
github.com/opencontainers/image-tools/image
github.com/opencontainers/image-tools/cmd/oci-create-runtime-bundle
go build -v -ldflags "-X main.gitCommit=0a1e5dc0c9b67619d46bd8cbcc948bda1b143b27" ./cmd/oci-image-validate
github.com/opencontainers/image-tools/vendor/github.com/opencontainers/image-spec/specs-go
github.com/opencontainers/image-tools/vendor/github.com/pkg/errors
github.com/opencontainers/image-tools/vendor/github.com/xeipuuv/gojsonpointer
github.com/opencontainers/image-tools/vendor/go4.org/errorutil
github.com/opencontainers/image-tools/vendor/github.com/opencontainers/image-spec/specs-go/v1
github.com/opencontainers/image-tools/vendor/github.com/opencontainers/runtime-spec/specs-go
github.com/opencontainers/image-tools/vendor/github.com/spf13/pflag
github.com/opencontainers/image-tools/vendor/github.com/xeipuuv/gojsonreference
github.com/opencontainers/image-tools/vendor/github.com/xeipuuv/gojsonschema
github.com/opencontainers/image-tools/vendor/github.com/spf13/cobra
github.com/opencontainers/image-tools/vendor/github.com/opencontainers/image-spec/schema
github.com/opencontainers/image-tools/image
github.com/opencontainers/image-tools/cmd/oci-image-validate
go build -v -ldflags "-X main.gitCommit=0a1e5dc0c9b67619d46bd8cbcc948bda1b143b27" ./cmd/oci-unpack
github.com/opencontainers/image-tools/vendor/github.com/opencontainers/image-spec/specs-go
github.com/opencontainers/image-tools/vendor/github.com/pkg/errors
github.com/opencontainers/image-tools/vendor/github.com/xeipuuv/gojsonpointer
github.com/opencontainers/image-tools/vendor/go4.org/errorutil
github.com/opencontainers/image-tools/vendor/github.com/opencontainers/image-spec/specs-go/v1
github.com/opencontainers/image-tools/vendor/github.com/opencontainers/runtime-spec/specs-go
github.com/opencontainers/image-tools/vendor/github.com/xeipuuv/gojsonreference
github.com/opencontainers/image-tools/vendor/github.com/spf13/pflag
github.com/opencontainers/image-tools/vendor/github.com/xeipuuv/gojsonschema
github.com/opencontainers/image-tools/vendor/github.com/spf13/cobra
github.com/opencontainers/image-tools/vendor/github.com/opencontainers/image-spec/schema
github.com/opencontainers/image-tools/image
github.com/opencontainers/image-tools/cmd/oci-unpack
```

**go test flag**
```shell
$ make GOFLAG="-v" test
go test -race -cover -v github.com/opencontainers/image-tools/cmd/oci-create-runtime-bundle github.com/opencontainers/image-tools/cmd/oci-image-validate github.com/opencontainers/image-tools/cmd/oci-unpack github.com/opencontainers/image-tools/image
?   	github.com/opencontainers/image-tools/cmd/oci-create-runtime-bundle	[no test files]
?   	github.com/opencontainers/image-tools/cmd/oci-image-validate	[no test files]
?   	github.com/opencontainers/image-tools/cmd/oci-unpack	[no test files]
=== RUN   TestValidateLayout
--- PASS: TestValidateLayout (0.02s)
=== RUN   TestUnpackLayerDuplicateEntries
--- PASS: TestUnpackLayerDuplicateEntries (0.01s)
=== RUN   TestUnpackLayer
--- PASS: TestUnpackLayer (0.01s)
=== RUN   TestUnpackLayerRemovePartialyUnpackedFile
--- PASS: TestUnpackLayerRemovePartialyUnpackedFile (0.01s)
=== RUN   TestNewTarWalker
--- PASS: TestNewTarWalker (0.00s)
PASS
coverage: 34.5% of statements
ok  	github.com/opencontainers/image-tools/image	1.054s	coverage: 34.5% of statements
```
