### PR TITLE
Validate main.go:add warning

### DIFF
--- a/cmd/oci-image-validate/main.go
+++ b/cmd/oci-image-validate/main.go
@@ -158,6 +158,10 @@ func (v *validateCmd) validatePath(name string) error {
 		return image.Validate(name, v.refs, v.stdout)
 	}
 
+	if len(v.refs) != 0 {
+		fmt.Printf("WARNING: type %q does not support refs, which are only appropriate if type is image or imageLayout.\n", typ)
+	}
+
 	f, err := os.Open(name)
 	if err != nil {
 		return errors.Wrap(err, "unable to open file")


### PR DESCRIPTION
Increases the warning when the ref's use does not conform to the specification
Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>