### PR TITLE
image.go:change out.Print to fmt.Errorf

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -57,7 +57,7 @@ func validate(w walker, refs []string, out *log.Logger) error {
 		// TODO(runcom): ugly, we'll need a better way and library
 		// to express log levels.
 		// see https://github.com/opencontainers/image-spec/issues/288
-		out.Print("WARNING: no descriptors found")
+		return fmt.Errorf("no descriptors found")
 	}
 
 	if len(refs) == 0 {


### PR DESCRIPTION
I think we should return an error here, if it is to use WARING, then the validate function will return nil, and ultimately make the verification results are wrong
Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>