### PR TITLE
config.go:Drop local rootfs.type validation

### DIFF
--- a/image/config.go
+++ b/image/config.go
@@ -53,10 +53,7 @@ func findConfig(w walker, d *descriptor) (*config, error) {
 		if err := json.Unmarshal(buf, &c); err != nil {
 			return err
 		}
-		// check if the rootfs type is 'layers'
-		if c.RootFS.Type != "layers" {
-			return fmt.Errorf("%q is an unknown rootfs type, MUST be 'layers'", c.RootFS.Type)
-		}
+
 		return errEOW
 	}); err {
 	case nil:


### PR DESCRIPTION
In this type of authentication is not required, because the json file has been identified [type value](https://github.com/opencontainers/image-spec/blame/master/schema/defs-config.json#L81) ，if not the case, it will never perform type validation.

Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>