### PR TITLE
Modify the ref information

### DIFF
--- a/cmd/oci-image-tool/create.go
+++ b/cmd/oci-image-tool/create.go
@@ -90,7 +90,7 @@ var createCommand = cli.Command{
 		cli.StringFlag{
 			Name:  "ref",
 			Value: "v1.0",
-			Usage: "The ref pointing to the manifest of the OCI image. This must be present in the 'refs' subdirectory of the image.",
+			Usage: "The ref pointing to the manifest of the OCI image. This must be match 'org.opencontainers.image.ref.name' annotations in index.json.",
 		},
 		cli.StringFlag{
 			Name:  "rootfs",

--- a/cmd/oci-image-tool/unpack.go
+++ b/cmd/oci-image-tool/unpack.go
@@ -86,7 +86,7 @@ var unpackCommand = cli.Command{
 		cli.StringFlag{
 			Name:  "ref",
 			Value: "v1.0",
-			Usage: "The ref pointing to the manifest of the OCI image. This must be present in the 'refs' subdirectory of the image.",
+			Usage: "The ref pointing to the manifest of the OCI image. This must be match 'org.opencontainers.image.ref.name' annotations in index.json.",
 		},
 		cli.StringFlag{
 			Name:  "platform",

--- a/cmd/oci-image-tool/validate.go
+++ b/cmd/oci-image-tool/validate.go
@@ -140,7 +140,7 @@ var validateCommand = cli.Command{
 		},
 		cli.StringSliceFlag{
 			Name:  "ref",
-			Usage: "A set of refs pointing to the manifests to be validated. Each reference must be present in the refs subdirectory of the image. Only applicable if type is image or imageLayout.",
+			Usage: "A set of refs pointing to the manifests to be validated. Each reference must be match 'org.opencontainers.image.ref.name' annotations in index.json. Only applicable if type is image or imageLayout.",
 		},
 	},
 }

--- a/man/oci-image-tool-create.1.md
+++ b/man/oci-image-tool-create.1.md
@@ -18,7 +18,7 @@ runtime-spec-compatible `dest/config.json`.
   Print usage statement
 
 **--ref**=""
-  The ref pointing to the manifest of the OCI image. This must be present in the "refs" subdirectory of the image. (default "v1.0")
+  The ref pointing to the manifest of the OCI image. This must be match 'org.opencontainers.image.ref.name' annotations in index.json. (default "v1.0")
 
 **--rootfs**=""
   A directory representing the root filesystem of the container in the OCI runtime bundle. It is strongly recommended to keep the default value. (default "rootfs")

--- a/man/oci-image-tool-unpack.1.md
+++ b/man/oci-image-tool-unpack.1.md
@@ -15,7 +15,7 @@ oci-image-tool unpack \- Unpack an image or image source layout
   Print usage statement
 
 **--ref**=""
-  The ref pointing to the manifest to be unpacked. This must be present in the "refs" subdirectory of the image. (default "v1.0")
+  The ref pointing to the manifest to be unpacked. This must be match 'org.opencontainers.image.ref.name' annotations in index.json. (default "v1.0")
 
 **--type**=""
   Type of the file to unpack. If unset, oci-image-tool will try to auto-detect the type. One of "imageLayout,image"

--- a/man/oci-image-tool-validate.1.md
+++ b/man/oci-image-tool-validate.1.md
@@ -18,7 +18,7 @@ oci-image-tool validate \- Validate one or more image files
 **--ref**=[]
   The reference to validate (should point to a manifest).
   Can be specified multiple times to validate multiple references.
-  `NAME` must be present in the `refs` subdirectory of the image.
+  `NAME` must be match 'org.opencontainers.image.ref.name' annotations in index.json.
   Only applicable if type is image or imageLayout.
 
 **--type**=""


### PR DESCRIPTION
According to some [norms](https://github.com/opencontainers/image-spec/blame/master/image-layout.md#L74) can be seen, ref can also point to the manifest list, here only to modify some of the error message, some code error will continue to update in #51 .

I think it's more appropriate to change ref to tag. 

Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>