### PR TITLE
manifest.go:remove the size of the layers of judgment

### DIFF
--- a/image/manifest.go
+++ b/image/manifest.go
@@ -59,10 +59,6 @@ func findManifest(w walker, d *descriptor) (*manifest, error) {
 			return err
 		}
 
-		if len(m.Layers) == 0 {
-			return fmt.Errorf("%s: no layers found", path)
-		}
-
 		return errEOW
 	}); err {
 	case nil:


### PR DESCRIPTION
According to [this](https://github.com/opencontainers/image-spec/blame/master/schema/image-manifest-schema.json#L26) ，we can see the minimum length of the layer has been verified in JSON, so the code is redundant.
Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>