### PR TITLE
manifest.go: Remove the extra judgment for layers

### DIFF
--- a/image/manifest.go
+++ b/image/manifest.go
@@ -107,10 +107,6 @@ func (m *manifest) unpack(w walker, dest string) (retErr error) {
 		}
 	}()
 	for _, d := range m.Layers {
-		if d.MediaType != string(schema.MediaTypeImageLayer) {
-			continue
-		}
-
 		switch err := w.walk(func(path string, info os.FileInfo, r io.Reader) error {
 			if info.IsDir() {
 				return nil


### PR DESCRIPTION
In the process of the validation have been carried out for the validation of the [layers,](https://github.com/opencontainers/image-tools/blame/master/image/manifest.go#L83) So they are not needed in the unpack function.
Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>