### PR TITLE
validate.md: delete the ref's default value

### DIFF
--- a/cmd/oci-image-validate/oci-image-validate.1.md
+++ b/cmd/oci-image-validate/oci-image-validate.1.md
@@ -20,7 +20,6 @@ oci-image-validate \- Validate one or more image files
   The reference to validate (should point to a manifest).
   Can be specified multiple times to validate multiple references.
   `NAME` must be present in the `refs` subdirectory of the image.
-  Defaults to `v1.0`.
   Only applicable if type is image or imageLayout.
 
 **--type**


### PR DESCRIPTION
There is no default value given to the ref option, so should remove this statement.

Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>