### PR TITLE
image: Port to go-digest

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9b4441d8a5beafc0334e55c3c0c98e32b60d51d7b0ceba8110b61b26f2b498fa
-updated: 2017-02-06T10:48:09.882426248+08:00
+hash: 96d33c78edbe7fe735d07563db6d34f7493db27e52984ada2ff5aaa2ea434979
+updated: 2017-02-06T21:22:16.913065811-08:00
 imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,7 @@
 package: github.com/opencontainers/image-tools
 import:
+- package: github.com/opencontainers/go-digest
+  version: v1.0.0-rc0
 - package: github.com/opencontainers/image-spec
   version: v1.0.0-rc4
   subpackages:


### PR DESCRIPTION
This is the smallest pivot I could think up (replacing old sha256 imports with go-digest).  But I want the go-digest vendoring to land so I can rebase #5 and #40 on top of it.  And I expect folks who currently prefer other methods for cleaning up the internal image/* code are also interested in go-digest, so I'm filing this PR to get a base that we hopefully all agree on ;).