### PR TITLE
image: make layer validation work

### DIFF
--- a/image/manifest.go
+++ b/image/manifest.go
@@ -75,8 +75,15 @@ func (m *manifest) validate(w walker) error {
 		return errors.Wrap(err, "config validation failed")
 	}
 
+	validLayerMediaTypes := []string{
+		v1.MediaTypeImageLayer,
+		v1.MediaTypeImageLayerGzip,
+		v1.MediaTypeImageLayerNonDistributable,
+		v1.MediaTypeImageLayerNonDistributableGzip,
+	}
+
 	for _, d := range m.Layers {
-		if err := d.validate(w, []string{v1.MediaTypeImageLayer}); err != nil {
+		if err := d.validate(w, validLayerMediaTypes); err != nil {
 			return errors.Wrap(err, "layer validation failed")
 		}
 	}


### PR DESCRIPTION
Most recently, the validation was broken because the image-spec was
re-vendored but the code handling MediaType validation was not updated.

This change (among others) broke umoci's tests because we run the
validation code to ensure our images are always valid, and the
validation incorrectly flagged our images as invalid.

Fixes: ff477b3a7e85 ("vendor:update")
Signed-off-by: Aleksa Sarai <asarai@suse.de>