### PR TITLE
Makefile: Add $(TOOLS) to .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ clean:
 .PHONY: \
 	all \
 	tools \
+	$(TOOLS) \
 	man \
 	install \
 	uninstall \


### PR DESCRIPTION
Modify the command can be reused, the following problems will not occur：
`make: Nothing to be done for 'tools'.`
Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>