### PR TITLE
image: Consistent reader usage

### DIFF
--- a/image/descriptor.go
+++ b/image/descriptor.go
@@ -93,7 +93,7 @@ func findDescriptor(w walker, name string) (*descriptor, error) {
 	}
 }
 
-func (d *descriptor) validate(w walker, mts []string) error {
+func (d *descriptor) validate(get reader, mts []string) error {
 	var found bool
 	for _, mt := range mts {
 		if d.MediaType == mt {
@@ -105,7 +105,7 @@ func (d *descriptor) validate(w walker, mts []string) error {
 		return fmt.Errorf("invalid descriptor MediaType %q", d.MediaType)
 	}
 
-	rc, err := w.Get(*d)
+	rc, err := get.Get(*d)
 	if err != nil {
 		return err
 	}

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -60,8 +60,8 @@ func findManifest(get reader, d *descriptor) (*manifest, error) {
 	return &m, nil
 }
 
-func (m *manifest) validate(w walker) error {
-	if err := m.Config.validate(w, []string{v1.MediaTypeImageConfig}); err != nil {
+func (m *manifest) validate(get reader) error {
+	if err := m.Config.validate(get, []string{v1.MediaTypeImageConfig}); err != nil {
 		return errors.Wrap(err, "config validation failed")
 	}
 
@@ -73,7 +73,7 @@ func (m *manifest) validate(w walker) error {
 	}
 
 	for _, d := range m.Layers {
-		if err := d.validate(w, validLayerMediaTypes); err != nil {
+		if err := d.validate(get, validLayerMediaTypes); err != nil {
 			return errors.Wrap(err, "layer validation failed")
 		}
 	}

--- a/image/manifest_test.go
+++ b/image/manifest_test.go
@@ -111,7 +111,8 @@ func TestUnpackLayer(t *testing.T) {
 			Digest:    digester.Digest().String(),
 		}},
 	}
-	err = testManifest.unpack(newPathWalker(tmp1), filepath.Join(tmp1, "rootfs"))
+	get := &layoutReader{root: tmp1}
+	err = testManifest.unpack(get, filepath.Join(tmp1, "rootfs"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +172,8 @@ func TestUnpackLayerRemovePartialyUnpackedFile(t *testing.T) {
 			Digest:    digester.Digest().String(),
 		}},
 	}
-	err = testManifest.unpack(newPathWalker(tmp1), filepath.Join(tmp1, "rootfs"))
+	get := &layoutReader{root: tmp1}
+	err = testManifest.unpack(get, filepath.Join(tmp1, "rootfs"))
 	if err != nil && !strings.Contains(err.Error(), "duplicate entry for") {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Start distinguishing between `reader` (when you only need to `Get` CAS blobs) and `walker` (when you might also need to access mutable refs).  This lays the ground work for something like #5, but avoids the contentious invention of new interfaces by sticking to interfaces which have already landed in master.  Also removes a number of redundant `Get` re-implementations.