### PR TITLE
bump dummy version

### DIFF
--- a/cmd/oci-create-runtime-bundle/main.go
+++ b/cmd/oci-create-runtime-bundle/main.go
@@ -22,6 +22,7 @@ import (
 
 	specs "github.com/opencontainers/image-spec/specs-go"
 	"github.com/opencontainers/image-tools/image"
+	"github.com/opencontainers/image-tools/version"
 	"github.com/spf13/cobra"
 )
 
@@ -107,6 +108,7 @@ It is strongly recommended to keep the default value.`,
 func (v *bundleCmd) Run(cmd *cobra.Command, args []string) {
 	if v.version {
 		v.stdout.Printf("commit: %s", gitCommit)
+		v.stdout.Printf("version: %s", version.Version)
 		v.stdout.Printf("spec: %s", specs.Version)
 		os.Exit(0)
 

--- a/cmd/oci-image-validate/main.go
+++ b/cmd/oci-image-validate/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/opencontainers/image-spec/schema"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	"github.com/opencontainers/image-tools/image"
+	"github.com/opencontainers/image-tools/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -104,6 +105,7 @@ func newValidateCmd(stdout, stderr *log.Logger) *cobra.Command {
 func (v *validateCmd) Run(cmd *cobra.Command, args []string) {
 	if v.version {
 		v.stdout.Printf("commit: %s", gitCommit)
+		v.stdout.Printf("version: %s", version.Version)
 		v.stdout.Printf("spec: %s", specs.Version)
 		os.Exit(0)
 	}

--- a/cmd/oci-unpack/main.go
+++ b/cmd/oci-unpack/main.go
@@ -22,6 +22,7 @@ import (
 
 	specs "github.com/opencontainers/image-spec/specs-go"
 	"github.com/opencontainers/image-tools/image"
+	"github.com/opencontainers/image-tools/version"
 	"github.com/spf13/cobra"
 )
 
@@ -100,6 +101,7 @@ func newUnpackCmd(stdout, stderr *log.Logger) *cobra.Command {
 func (v *unpackCmd) Run(cmd *cobra.Command, args []string) {
 	if v.version {
 		v.stdout.Printf("commit: %s", gitCommit)
+		v.stdout.Printf("version: %s", version.Version)
 		v.stdout.Printf("spec: %s", specs.Version)
 		os.Exit(0)
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,32 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import "fmt"
+
+const (
+	// VersionMajor is for an API incompatible changes
+	VersionMajor = 0
+	// VersionMinor is for functionality in a backwards-compatible manner
+	VersionMinor = 0
+	// VersionPatch is for backwards-compatible bug fixes
+	VersionPatch = 0
+
+	// VersionDev indicates development branch. Releases will be empty string.
+	VersionDev = "-dev"
+)
+
+// Version is the specification version that the package types support.
+var Version = fmt.Sprintf("%d.%d.%d%s", VersionMajor, VersionMinor, VersionPatch, VersionDev)


### PR DESCRIPTION
During bumping official version, it should not change any code. So, it
has to prepare the version variables, their functions and dummy version
(as 0.0.0-dev) into code. After that is landed, then official versions
can be released.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>