### PR TITLE
fix bug of failure on make lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.6
   - 1.7
+  - 1.8
 
 sudo: required
 

--- a/image/autodetect.go
+++ b/image/autodetect.go
@@ -70,7 +70,7 @@ func Autodetect(path string) (string, error) {
 		return "", errors.New("unknown file type")
 	}
 
-	if _, err := f.Seek(0, os.SEEK_SET); err != nil {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		return "", errors.Wrap(err, "unable to seek")
 	}
 
@@ -81,7 +81,7 @@ func Autodetect(path string) (string, error) {
 	}{}
 
 	if err := json.NewDecoder(f).Decode(&header); err != nil {
-		if _, errSeek := f.Seek(0, os.SEEK_SET); errSeek != nil {
+		if _, errSeek := f.Seek(0, io.SeekStart); errSeek != nil {
 			return "", errors.Wrap(err, "unable to seek")
 		}
 

--- a/image/walker.go
+++ b/image/walker.go
@@ -49,7 +49,7 @@ func newTarWalker(tarFile string, r io.ReadSeeker) walker {
 }
 
 func (w *tarWalker) walk(f walkFunc) error {
-	if _, err := w.r.Seek(0, os.SEEK_SET); err != nil {
+	if _, err := w.r.Seek(0, io.SeekStart); err != nil {
 		return errors.Wrapf(err, "unable to reset")
 	}
 


### PR DESCRIPTION
It is because golang version than 1.7 prompts as when golint,
```
os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (SA1019) (staticcheck)
```

Signed-off-by: xiekeyang <xiekeyang@huawei.com>