### PR TITLE
cmd/oci-image-tool/validate.go: create a logger if none exists.

### DIFF
--- a/cmd/oci-image-tool/validate.go
+++ b/cmd/oci-image-tool/validate.go
@@ -96,6 +96,10 @@ func validatePath(name string) error {
 		}
 	}
 
+	if v.stdout == nil {
+		v.stdout = log.New(os.Stdout, "oci-image-tool: ", 0)
+	}
+
 	switch typ {
 	case image.TypeImageLayout:
 		return image.ValidateLayout(name, v.refs, v.stdout)


### PR DESCRIPTION
This was causing panics when validating an image with no refs, hitting this line of code, causing a panic on `out` being nil: https://github.com/opencontainers/image-tools/blob/master/image/image.go#L60

Thanks!
