### PR TITLE
image/manifest.go: implement compression detection / mediatype validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ lint:
 	@./.tool/lint
 
 test:
-	go test -race -cover $(shell go list ./... | grep -v /vendor/)
+	go test -v -race -cover $(shell go list ./... | grep -v /vendor/)
 
 
 ## this uses https://github.com/Masterminds/glide and https://github.com/sgotti/glide-vc


### PR DESCRIPTION
Previously, this would effectively panic on any tar files because it was
expecting a gzip compressed file. This enforces that the `+gzip` media
type exists before enabling gzip decompression.

I also shimmed in some tests by appropriating some others.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>