### PR TITLE
.pullapprove.yml: Switch to v2 and other updates

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,12 +1,27 @@
-approve_by_comment: true
-approve_regex: '^(Approved|lgtm|LGTM|:shipit:|:star:|:\+1:|:ship:)'
-reject_regex: ^Rejected
-reset_on_push: true
-author_approval: ignored
-signed_off_by:
-  required: true
-reviewers:
-  teams:
-  - image-tools-maintainers
-  name: default
+version: 2
+
+requirements:
+  signed_off_by:
+    required: true
+
+group_defaults:
   required: 2
+  approve_by_comment:
+    enabled: true
+    approve_regex: '^(Approved|lgtm|LGTM|:shipit:|:star:|:\+1:|:ship:)'
+    reject_regex: ^Rejected
+  reset_on_push:
+    enabled: true
+  author_approval:
+    ignored: true
+  always_pending:
+    title_regex: ^WIP
+    explanation: 'Work in progress...'
+  conditions:
+    branches:
+      - master
+
+groups:
+  image-tools:
+    teams:
+      - image-tools-maintainers


### PR DESCRIPTION
This lazily copies image-spec's configuration as updated via
https://github.com/opencontainers/project-template/pull/29 and
https://github.com/opencontainers/image-spec/pull/616

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>