### PR TITLE
fix help info for --type option

### DIFF
--- a/cmd/oci-image-tool/create.go
+++ b/cmd/oci-image-tool/create.go
@@ -81,7 +81,7 @@ var createCommand = cli.Command{
 		cli.StringFlag{
 			Name: "type",
 			Usage: fmt.Sprintf(
-				`Type of the file to unpack. If unset, oci-image-tool-validate will try to auto-detect the type. One of "%s".`,
+				`Type of the file to unpack. If unset, oci-image-tool will try to auto-detect the type. One of "%s".`,
 				strings.Join(bundleTypes, ","),
 			),
 		},

--- a/cmd/oci-image-tool/unpack.go
+++ b/cmd/oci-image-tool/unpack.go
@@ -77,7 +77,7 @@ var unpackCommand = cli.Command{
 		cli.StringFlag{
 			Name: "type",
 			Usage: fmt.Sprintf(
-				`Type of the file to unpack. If unset, oci-image-tool-validate will try to auto-detect the type. One of "%s".`,
+				`Type of the file to unpack. If unset, oci-image-tool will try to auto-detect the type. One of "%s".`,
 				strings.Join(unpackTypes, ","),
 			),
 		},

--- a/cmd/oci-image-tool/validate.go
+++ b/cmd/oci-image-tool/validate.go
@@ -134,7 +134,7 @@ var validateCommand = cli.Command{
 		cli.StringFlag{
 			Name: "type",
 			Usage: fmt.Sprintf(
-				`Type of the file to validate. If unset, oci-image-tool-validate will try to auto-detect the type. One of "%s".`,
+				`Type of the file to validate. If unset, oci-image-tool will try to auto-detect the type. One of "%s".`,
 				strings.Join(validateTypes, ","),
 			),
 		},


### PR DESCRIPTION
oci-image-tool-validate is not correct any more, fix it.

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>