### PR TITLE
image: optimize file searching

### DIFF
--- a/image/config.go
+++ b/image/config.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -35,10 +34,7 @@ func findConfig(w walker, d *v1.Descriptor) (*v1.Image, error) {
 	var c v1.Image
 	cpath := filepath.Join("blobs", string(d.Digest.Algorithm()), d.Digest.Hex())
 
-	switch err := w.walk(func(path string, info os.FileInfo, r io.Reader) error {
-		if info.IsDir() || filepath.Clean(path) != cpath {
-			return nil
-		}
+	switch err := w.find(cpath, func(path string, r io.Reader) error {
 		buf, err := ioutil.ReadAll(r)
 		if err != nil {
 			return errors.Wrapf(err, "%s: error reading config", path)

--- a/image/descriptor.go
+++ b/image/descriptor.go
@@ -53,12 +53,9 @@ func listReferences(w walker) ([]v1.Descriptor, error) {
 func findDescriptor(w walker, names []string) ([]v1.Descriptor, error) {
 	var descs []v1.Descriptor
 	var index v1.Index
+	dpath := "index.json"
 
-	if err := w.walk(func(path string, info os.FileInfo, r io.Reader) error {
-		if info.IsDir() || filepath.Clean(path) != indexPath {
-			return nil
-		}
-
+	if err := w.find(dpath, func(path string, r io.Reader) error {
 		if err := json.NewDecoder(r).Decode(&index); err != nil {
 			return err
 		}


### PR DESCRIPTION
walkFunc is inefficient. If we knows which file to read, there is no need to call w.walk().
For imageLayout, w.find() will improve the file searching speed.

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>