### PR TITLE
make the image-tool work with -rc5

### DIFF
--- a/image/config.go
+++ b/image/config.go
@@ -33,9 +33,9 @@ import (
 
 type config v1.Image
 
-func findConfig(w walker, d *descriptor) (*config, error) {
+func findConfig(w walker, d *v1.Descriptor) (*config, error) {
 	var c config
-	cpath := filepath.Join("blobs", d.algo(), d.hash())
+	cpath := filepath.Join("blobs", string(d.Digest.Algorithm()), d.Digest.Hex())
 
 	switch err := w.walk(func(path string, info os.FileInfo, r io.Reader) error {
 		if info.IsDir() || filepath.Clean(path) != cpath {

--- a/image/image.go
+++ b/image/image.go
@@ -84,7 +84,7 @@ func validate(w walker, refs []string, out *log.Logger) error {
 			return fmt.Errorf("reference %s not found", ref)
 		}
 
-		if err = d.validate(w, validRefMediaTypes); err != nil {
+		if err = validateDescriptor(d, w, validRefMediaTypes); err != nil {
 			return err
 		}
 
@@ -135,7 +135,7 @@ func unpack(w walker, dest, refName string) error {
 		return err
 	}
 
-	if err = ref.validate(w, validRefMediaTypes); err != nil {
+	if err = validateDescriptor(ref, w, validRefMediaTypes); err != nil {
 		return err
 	}
 
@@ -183,7 +183,7 @@ func createRuntimeBundle(w walker, dest, refName, rootfs string) error {
 		return err
 	}
 
-	if err = ref.validate(w, validRefMediaTypes); err != nil {
+	if err = validateDescriptor(ref, w, validRefMediaTypes); err != nil {
 		return err
 	}
 

--- a/image/manifest_test.go
+++ b/image/manifest_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 
 	bz2 "github.com/dsnet/compress/bzip2"
@@ -141,7 +142,7 @@ func testUnpackLayer(t *testing.T, compression string, invalid bool) {
 	}
 
 	testManifest := manifest{
-		Layers: []descriptor{descriptor{
+		Layers: []v1.Descriptor{v1.Descriptor{
 			MediaType: mediatype,
 			Digest:    digester.Digest(),
 		}},
@@ -210,7 +211,7 @@ func TestUnpackLayerRemovePartialyUnpackedFile(t *testing.T) {
 	}
 
 	testManifest := manifest{
-		Layers: []descriptor{descriptor{
+		Layers: []v1.Descriptor{v1.Descriptor{
 			MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
 			Digest:    digester.Digest(),
 		}},

--- a/image/manifest_test.go
+++ b/image/manifest_test.go
@@ -143,7 +143,7 @@ func testUnpackLayer(t *testing.T, compression string, invalid bool) {
 	testManifest := manifest{
 		Layers: []descriptor{descriptor{
 			MediaType: mediatype,
-			Digest:    digester.Digest().String(),
+			Digest:    digester.Digest(),
 		}},
 	}
 	err = testManifest.unpack(newPathWalker(tmp1), filepath.Join(tmp1, "rootfs"))
@@ -212,7 +212,7 @@ func TestUnpackLayerRemovePartialyUnpackedFile(t *testing.T) {
 	testManifest := manifest{
 		Layers: []descriptor{descriptor{
 			MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
-			Digest:    digester.Digest().String(),
+			Digest:    digester.Digest(),
 		}},
 	}
 	err = testManifest.unpack(newPathWalker(tmp1), filepath.Join(tmp1, "rootfs"))


### PR DESCRIPTION
This is a #121 follow-up PR, make the image-tool work with -rc5. Sorry so late update.

Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>