### PR TITLE
remove duplicated error printing

### DIFF
--- a/cmd/oci-image-tool/create.go
+++ b/cmd/oci-image-tool/create.go
@@ -68,10 +68,6 @@ func createHandle(context *cli.Context) error {
 
 	}
 
-	if err != nil {
-		fmt.Printf("creating failed: %v\n", err)
-	}
-
 	return err
 }
 

--- a/cmd/oci-image-tool/unpack.go
+++ b/cmd/oci-image-tool/unpack.go
@@ -65,9 +65,6 @@ func unpackHandle(context *cli.Context) error {
 		err = fmt.Errorf("cannot unpack %q", v.typ)
 	}
 
-	if err != nil {
-		fmt.Printf("unpacking failed: %v\n", err)
-	}
 	return err
 }
 

--- a/image/descriptor.go
+++ b/image/descriptor.go
@@ -76,7 +76,7 @@ func findDescriptor(w walker, name string) (*v1.Descriptor, error) {
 		return nil
 	}); err {
 	case nil:
-		return nil, fmt.Errorf("index.json: descriptor not found")
+		return nil, fmt.Errorf("index.json: descriptor %q not found", name)
 	case errEOW:
 		return &d, nil
 	default:


### PR DESCRIPTION
Without this fix, result was:
```
$ oci-image-tool create --platform linux  busybox-oci testdir
creating failed: index.json: descriptor not found
index.json: descriptor not found
```
duplicated errors are printed and we don't know which descriptor can't be found.

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>