### PR TITLE
validate: remove autodetect for type and add require limit

### DIFF
--- a/cmd/oci-create-runtime-bundle/oci-create-runtime-bundle.1.md
+++ b/cmd/oci-create-runtime-bundle/oci-create-runtime-bundle.1.md
@@ -1,0 +1,46 @@
+% OCI(1) OCI-CREATE-RUNTIME-BUNDLE User Manuals
+% OCI Community
+% JULY 2016
+# NAME
+oci-create-runtime-bundle \- Create an OCI runtime bundle
+
+# SYNOPSIS
+**oci-create-runtime-bundle** [src] [dest] [flags]
+**oci-create-runtime-bundle** [--help|-v|--version]
+
+# DESCRIPTION
+`oci-create-runtime-bundle` validates an application/vnd.oci.image.manifest.v1+json and unpacks its layered filesystem to `dest/rootfs`, although the target directory is configurable with `--rootfs`. See **oci-unpack**(1) for more details on this process.
+
+Also translates the referenced config from application/vnd.oci.image.config.v1+json to a
+runtime-spec-compatible `dest/config.json`.
+
+# FLAGS
+**--help**
+  Print usage statement
+
+**--ref**=""
+  The ref pointing to the manifest of the OCI image. This must be present in the "refs" subdirectory of the image. (default "v1.0")
+
+**--rootfs**=""
+  A directory representing the root filesystem of the container in the OCI runtime bundle. It is strongly recommended to keep the default value. (default "rootfs")
+
+**--type**=""
+  Type of the file to unpack. If unset, oci-create-runtime-bundle will try to auto-detect the type. One of "imageLayout,image"
+
+**-v**, **--version**
+  Print version information and exit.
+
+# EXAMPLES
+```
+$ skopeo copy docker://busybox oci:busybox-oci
+$ mkdir busybox-bundle
+$ oci-create-runtime-bundle --ref latest busybox-oci busybox-bundle
+$ cd busybox-bundle && sudo runc run busybox
+[...]
+```
+
+# SEE ALSO
+**runc**(1), **skopeo**(1)
+
+# HISTORY
+Sept 2016, Originally compiled by Antonio Murdaca (runcom at redhat dot com)

--- a/cmd/oci-image-validate/oci-image-validate.1.md
+++ b/cmd/oci-image-validate/oci-image-validate.1.md
@@ -1,0 +1,42 @@
+% OCI(1) OCI-IMAGE-VALIDATE User Manuals
+% OCI Community
+% JULY 2016
+# NAME
+oci-image-validate \- Validate one or more image files
+
+# SYNOPSIS
+**oci-image-validate** FILE... [flags]
+**oci-image-validate** [--help|-v|--version]
+
+# DESCRIPTION
+`oci-image-validate` validates the given file(s) against the OCI image specification.
+
+
+# FLAGS
+**--help**
+  Print usage statement
+
+**--ref**=[]
+  The reference to validate (should point to a manifest).
+  Can be specified multiple times to validate multiple references.
+  `NAME` must be present in the `refs` subdirectory of the image.
+  Only applicable if type is image or imageLayout.
+
+**--type**=""
+  Type of the file to validate. If unset, oci-image-validate will try to auto-detect the type. One of "imageLayout,image,manifest,manifestList,config"
+
+**-v**, **--version**
+  Print version information and exit.
+
+# EXAMPLES
+```
+$ skopeo copy docker://busybox oci:busybox-oci
+$ oci-image-validate --type imageLayout --ref latest busybox-oci
+busybox-oci: OK
+```
+
+# SEE ALSO
+**skopeo**(1)
+
+# HISTORY
+Sept 2016, Originally compiled by Antonio Murdaca (runcom at redhat dot com)

--- a/cmd/oci-unpack/oci-unpack.1.md
+++ b/cmd/oci-unpack/oci-unpack.1.md
@@ -1,0 +1,53 @@
+% OCI(1) OCI-UNPACK User Manuals
+% OCI Community
+% JULY 2016
+# NAME
+oci-unpack \- Unpack an image or image source layout
+
+# SYNOPSIS
+**oci-unpack** [src] [dest] [flags]
+**oci-unpack** [--help|-v|--version]
+
+# DESCRIPTION
+`oci-unpack` validates an application/vnd.oci.image.manifest.v1+json and unpacks its layered filesystem to `dest`.
+
+# FLAGS
+**--help**
+  Print usage statement
+
+**--ref**=""
+  The ref pointing to the manifest to be unpacked. This must be present in the "refs" subdirectory of the image. (default "v1.0")
+
+**--type**=""
+  Type of the file to unpack. If unset, oci-unpack will try to auto-detect the type. One of "imageLayout,image"
+
+**-v**, **--version**
+  Print version information and exit.
+
+# EXAMPLES
+```
+$ skopeo copy docker://busybox oci:busybox-oci
+$ mkdir busybox-bundle
+$ oci-unpack --ref latest busybox-oci busybox-bundle
+$ tree busybox-bundle
+busybox-bundle
+├── bin
+│   ├── [
+│   ├── [[
+│   ├── acpid
+│   ├── addgroup
+│   ├── add-shell
+│   ├── adduser
+│   ├── adjtimex
+│   ├── ar
+│   ├── arp
+│   ├── arping
+│   ├── ash
+[...]
+```
+
+# SEE ALSO
+**skopeo**(1)
+
+# HISTORY
+Sept 2016, Originally compiled by Antonio Murdaca (runcom at redhat dot com)

--- a/completions/bash/oci-image-tool
+++ b/completions/bash/oci-image-tool
@@ -113,8 +113,6 @@ __oci-image-tool_complete_validate_types() {
 		config
 		image
 		imageIndex
-		imageLayout
-		imageZip
 		manifest
 	" -- "$cur" ) )
 }

--- a/man/oci-image-tool-validate.1.md
+++ b/man/oci-image-tool-validate.1.md
@@ -20,15 +20,15 @@ oci-image-tool validate \- Validate one or more image files
   Reference should point to a manifest or index.
   e.g. --ref name=v1.0 --ref platform.os=latest
   Only support `name`, `platform.os` and `digest` three cases.
-  Only applicable if type is image or imageLayout.
+  Only applicable if type is image.
 
 **--type**=""
-  Type of the file to validate. If unset, oci-image-tool will try to auto-detect the type. One of "imageLayout,image,imageZip,manifest,imageIndex,config"
+  Type of the file to validate. One of "image,manifest,imageIndex,config"
 
 # EXAMPLES
 ```
 $ skopeo copy docker://busybox oci:busybox-oci:latest
-$ oci-image-tool validate --type imageLayout --ref name=latest busybox-oci
+$ oci-image-tool validate --type image --ref name=latest busybox-oci
 busybox-oci: OK
 ```
 


### PR DESCRIPTION
1. spec says any extra fields in json file can be ignored, so I think
we can't clearly distingish which type the text file is, we'd better remove
autodetect for text files.
2. without audotdetect, we must requrie to user to set file type for validation

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>