### PR TITLE
.mailmap: Add entries for inconsistent users

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,8 @@
+Aleksa Sarai <asarai@suse.de> <cyphar@cyphar.com>
+Brandon Philips <brandon.philips@coreos.com> <brandon@ifup.org>
+Doug Davis <dug@us.ibm.com> <duglin@users.noreply.github.com>
+Sergiusz Urbaniak <sur@coreos.com> <sergiusz.urbaniak@gmail.com>
+Stephen J Day <stephen.day@docker.com> <stevvooe@users.noreply.github.com>
+xiekeyang <xiekeyang@huawei.com> <keyang.xie@gmail.com>
+xiekeyang <xiekeyang@huawei.com> <xiekeyang@users.noreply.github.com>
+Zhou Hao <zhouhao@cn.fujitsu.com>


### PR DESCRIPTION
Similar to https://github.com/opencontainers/runtime-tools/pull/115

Before this commit:
```
$ git shortlog -se 
  
     5  Aleksa Sarai <asarai@suse.de>
     1  Aleksa Sarai <cyphar@cyphar.com>
  ...
    38  Brandon Philips <brandon.philips@coreos.com>
     1  Brandon Philips <brandon@ifup.org>
  ...
     3  Doug Davis <dug@us.ibm.com>
     1  Doug Davis <duglin@users.noreply.github.com>
  ...
     3  Sergiusz Urbaniak <sergiusz.urbaniak@gmail.com>
    15  Sergiusz Urbaniak <sur@coreos.com>
  ...
    27  Stephen Day <stevvooe@users.noreply.github.com>
    15  Stephen J Day <stephen.day@docker.com>
 ...
     3  xiekeyang <keyang.xie@gmail.com>
    18  xiekeyang <xiekeyang@huawei.com>
```
Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>