### PR TITLE
191 docs fix skopeo copy cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The following examples assume you have a [image-layout](https://github.com/openc
 One way to acquire that image is with [skopeo](https://github.com/projectatomic/skopeo#installing):
 
 ```
-$ skopeo copy docker://busybox oci:busybox-oci
+$ skopeo copy docker://busybox oci:busybox-oci:busybox
 ```
 
 ### oci-image-tool-create


### PR DESCRIPTION
The change is simple, but I re-did the commit message to better follow the contributing guidelines, but unfortunately not before I had already published it -- therefore three commits.