### PR TITLE
Revert "Relax LGTMs"

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -5,7 +5,7 @@ requirements:
     required: true
 
 group_defaults:
-  required: 1
+  required: 2
   approve_by_comment:
     enabled: true
     approve_regex: '^(Approved|lgtm|LGTM|:shipit:|:star:|:\+1:|:ship:)'


### PR DESCRIPTION
This reverts commit e073febd8714374d6b459924cb0e2f2f998f6252.

This could only change with a proper vote by the project maintainers.
Pushing this through with only 2 maintainers was not acceptable.

Furthermore, if there are problems getting PRs through, it usually has
nothing to do with the number of maintainers on the project. It
typically comes down to the level of engineering work put into making
sure that a change is a clear and accurate solution to the problem. If
it is unclear whether or not a change has impact, then the default
reaction is to not merge the PR.

Signed-off-by: Stephen J Day <stephen.day@docker.com>