### PR TITLE
version: release 1.0.0-rc3

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc3"
+	VersionDev = "-rc3-dev"
 )
 
 // Version is the specification version that the package types support.

--- a/version/version.go
+++ b/version/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc1-dev"
+	VersionDev = "-rc3"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
When image-tools was split off from image-spec `1.0.0~rc2`, we downgraded
the effective version. This [caused issues with the Debian package][1], so
we need to bump the version to be later than `1.0.0~rc2` to resolve this
issue.

[1]: https://bugs.debian.org/900900

Fixes #204
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>