### PR TITLE
Fix invalid variable name in bash completion script

### DIFF
--- a/completions/bash/oci-image-tool
+++ b/completions/bash/oci-image-tool
@@ -22,7 +22,7 @@
 # options immediately following their corresponding long form.
 # This order should be applied to lists, alternatives and code blocks.
 
-__oci-image-tool_previous_extglob_setting=$(shopt -p extglob)
+__oci_image_tool_previous_extglob_setting=$(shopt -p extglob)
 shopt -s extglob
 
 __oci-image-tool_pos_first_nonflag() {
@@ -234,7 +234,7 @@ _oci-image-tool() {
 	return 0
 }
 
-eval "$__oci-image-tool_previous_extglob_setting"
-unset __oci-image-tool_previous_extglob_setting
+eval "$__oci_image_tool_previous_extglob_setting"
+unset __oci_image_tool_previous_extglob_setting
 
 complete -F _oci-image-tool oci-image-tool


### PR DESCRIPTION
Sourcing `completions/bash/oci-image-tool` in bash produces:

    bash: __oci-image-tool_previous_extglob_setting=shopt: command not found
    bash: eval: -i: invalid option
    eval: usage: eval [arg ...]

This occurs because `__oci-image-tool_previous_extglob_setting` is not a valid variable name (see https://unix.stackexchange.com/q/23659).

Fix the variable name by replacing `-` with `_`.  Since the variable is unset before the script finishes, this presents minimal compatibility risk.

Thanks for considering,
Kevin