### PR TITLE
Makefile: Add build mode pie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ check-license:
 
 .PHONY: tool
 tool:
-	go build -ldflags "-X main.gitCommit=${COMMIT}" -o oci-image-tool ./cmd/oci-image-tool
+	go build -ldflags "-X main.gitCommit=${COMMIT} -buildmode=pie" -o oci-image-tool ./cmd/oci-image-tool
 
 
 all: tool man


### PR DESCRIPTION
When using the lld linker, compilation with PIC is required. The bfd linker may allow it, but the lld linker requires recompilation with -fPIC if relocation is found in PIE.
```
aarch64-poky-linux-ld.lld: error: relocation R_AARCH64_ABS64 cannot be used against symbol 'type:.eq.[2]error'; recompile with -fPIC
>>> defined in /tmp/go-link-2192523349/go.o
>>> referenced by go.go
>>>               /tmp/go-link-2192523349/go.o:(.rodata+0x1730)
```